### PR TITLE
Hotfixed problem with visualizing a contest's problems

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ProblemsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ProblemsController.cs
@@ -524,7 +524,7 @@
         }
 
         [HttpGet]
-        public ContentResult ByContest(int id)
+        public ActionResult ByContest(int id)
         {
             var result = this.GetData(id);
             return this.LargeJson(result);

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ProblemsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ProblemsController.cs
@@ -524,11 +524,10 @@
         }
 
         [HttpGet]
-        public JsonResult ByContest(int id)
+        public ContentResult ByContest(int id)
         {
             var result = this.GetData(id);
-
-            return this.Json(result, JsonRequestBehavior.AllowGet);
+            return this.LargeJson(result);
         }
 
         [HttpGet]


### PR DESCRIPTION
Hotfixed the problem with visualizing a Contest's problems if the JSON data for the problems exceeded the default maxSize. It's a temporary solution and I've opened a issue for refactoring the Controllers.
Closed https://github.com/SoftUni-Internal/suls-issues/issues/1720
Closed https://github.com/SoftUni-Internal/suls-issues/issues/1286