### PR TITLE
Hotfixed a bug where importing new tests with the "Delete old Tests" …

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/TestsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/TestsController.cs
@@ -666,8 +666,11 @@
                 if (deleteOldFiles)
                 {
                     var testIds = this.Data.Tests.All().Where(t => t.ProblemId == problem.Id).Select(t => t.Id).ToList();
-                    this.Data.TestRuns.Delete(tr => testIds.Contains(tr.TestId));
-                    this.Data.Tests.Delete(t => testIds.Contains(t.Id));
+                    if (testIds.Any())
+                    {
+                        this.Data.TestRuns.Delete(tr => testIds.Contains(tr.TestId));
+                        this.Data.Tests.Delete(t => testIds.Contains(t.Id));
+                    }
                 }
 
                 ZippedTestsManipulator.AddTestsToProblem(problem, parsedTests);


### PR DESCRIPTION
…option checked while there were no new tests, caused an error in ASP.NET Delete method.

Closed SoftUni-Internal/suls-issues/issues/1743