### PR TITLE
Fix compilation problem in C++ strat due to headers

### DIFF
--- a/Open Judge System/Workers/OJS.Workers.Compilers/CPlusPlusZipCompiler.cs
+++ b/Open Judge System/Workers/OJS.Workers.Compilers/CPlusPlusZipCompiler.cs
@@ -11,7 +11,6 @@
     public class CPlusPlusZipCompiler : Compiler
     {
         private const string CPlusPlusClassFileExtension = ".cpp";
-        private const string CPlusPlusHeaderFileExtension = ".h";
         private const string CClassFileExtension = ".c";
 
         private readonly string workingDirectory;
@@ -54,8 +53,7 @@
                     SearchOption.AllDirectories)
                 .Where(f =>
                     f.EndsWith(CClassFileExtension) ||
-                    f.EndsWith(CPlusPlusClassFileExtension) ||
-                    f.EndsWith(CPlusPlusHeaderFileExtension));
+                    f.EndsWith(CPlusPlusClassFileExtension));
 
             foreach (var file in filesToCompile)
             {


### PR DESCRIPTION
Removed header files from compilation, which speeds up the compilation process

Closes SoftUni-Internal/suls-issues/issues/2204 - Optimize compile speed for larger C++ zip projects #2204