### PR TITLE
Bugs - Solution skeleton not being added upon problem creation

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ProblemsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ProblemsController.cs
@@ -186,6 +186,11 @@
                 }
             });
 
+            if (problem.SolutionSkeletonData != null && problem.SolutionSkeletonData.Any())
+            {
+                newProblem.SolutionSkeleton = problem.SolutionSkeletonData;
+            }
+
             if (problem.Resources != null && problem.Resources.Any())
             {
                 this.AddResourcesToProblem(newProblem, problem.Resources);


### PR DESCRIPTION
Implemented additional functionality for adding a SolutionSkeleton to a Problem when creating a Problem.
closes https://github.com/SoftUni-Internal/suls-issues/issues/2311