### PR TITLE
Bugs - CSharpProjectTestsExecutionStrategy fixed wrong PreprocessorHelper usage

### DIFF
--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
@@ -261,7 +261,7 @@
         {
             foreach (var test in tests)
             {
-                string testName = JavaCodePreprocessorHelper.GetClassName(test.Input);
+                string testName = CSharpPreprocessorHelper.GetClassName(test.Input);
                 this.TestNames.Add(testName);
             }           
         }


### PR DESCRIPTION
CSharpProjectTestsExecStrat is using the wrong preprocessor helper, should be fixed to use the correct one https://github.com/SoftUni-Internal/suls-issues/issues/2968