### PR TITLE
Added additional check for Admins/Lecturers before displaying Duration confirmation view

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Controllers/CompeteController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Controllers/CompeteController.cs
@@ -146,7 +146,8 @@
                         contest.IsOnline &&
                         (!hasConfirmed.HasValue ||
                         hasConfirmed.Value == false) &&
-                        contest.Duration.HasValue;
+                        contest.Duration.HasValue &&
+                        !this.IsUserAdminOrLecturerInContest(contest);
 
                     if (shouldShowConfirmation)
                     {


### PR DESCRIPTION
Users in Admin role should not have to go through the Duration confirmation view - closes https://github.com/SoftUni-Internal/suls-issues/issues/3737