### PR TITLE
Filtered contests only when passed string is not empty.

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ContestsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ContestsController.cs
@@ -295,8 +295,12 @@
                     c.Contests.Any(cc => !cc.IsDeleted && cc.Lecturers.Any(l => l.LecturerId == this.UserProfile.Id)));
             }
 
+            if (!string.IsNullOrWhiteSpace(contestFilter))
+            {
+                categories = categories.Where(c => c.Name.ToLower().Contains(contestFilter.ToLower()));
+            }
+
             var dropDownData = categories
-                .Where(c => c.Name.ToLower().Contains(contestFilter.ToLower()))
                 .ToList()
                 .Select(cat =>
                     new


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/suls-issues/issues/3741 - Fix Combobox on Contest Create/Edit page to show all entries, when there is no input value