### PR TITLE
Fixed Practice clock for online contest

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Participants/ParticipantViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Participants/ParticipantViewModel.cs
@@ -19,8 +19,7 @@
 
             if (official &&
                 !isAdminOrLecturer &&
-                this.Contest.IsOnline &&
-                (this.Contest.CanBeCompeted || participant.ContestEndTime >= DateTime.Now))
+                this.Contest.IsOnline)
             {
                 this.Contest.Problems = participant.Problems
                     .AsQueryable()

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Participants/ParticipantViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Participants/ParticipantViewModel.cs
@@ -42,7 +42,7 @@
         {
             get
             {
-                if (this.ContestEndTime.HasValue)
+                if (this.Contest.IsOnline && this.ContestIsCompete && this.ContestEndTime.HasValue)
                 {
                     return (this.ContestEndTime.Value - DateTime.Now).TotalMilliseconds;
                 }


### PR DESCRIPTION
When online contest is in Practice remaining time clock displays count down with time
Closes https://github.com/SoftUni-Internal/suls-issues/issues/3764