### PR TITLE
Fixed query to correctly display non-affected participants when subtr…

### DIFF
--- a/Open Judge System/OJS.Services/Business/Participants/IParticipantsBusinessService.cs
+++ b/Open Judge System/OJS.Services/Business/Participants/IParticipantsBusinessService.cs
@@ -15,7 +15,7 @@
             bool isAdmin);
 
         /// <summary>
-        /// Updates constest duration for participants in contest, 
+        /// Updates contest duration for participants in contest, 
         /// in time range with amount of minutes provided. If any participants' contest duration
         /// would be reduced below the base contest duration they are not updated.
         /// </summary>
@@ -24,10 +24,25 @@
         /// Amount can be negative</param>
         /// <param name="contestStartTimeRangeStart">The lower bound against which participants' contest start time would be checked</param>
         /// <param name="contestStartTimeRangeEnd">The upper bound against which participants' contest start time would be checked</param>
-        /// <returns>Returns participants who were not updated
-        /// because their contest duration would be reduced below
-        /// the base contest duration</returns>
-        IQueryable<Participant> UpdateContestEndTimeForAllParticipantsByContestByParticipantContestStartTimeRangeAndTimeIntervalInMinutes(
+        void UpdateContestEndTimeForAllParticipantsByContestByParticipantContestStartTimeRangeAndTimeIntervalInMinutes(
+            int contestId,
+            int minutes,
+            DateTime contestStartTimeRangeStart,
+            DateTime contestStartTimeRangeEnd);
+
+        /// <summary>
+        /// Filters participants whose contest duration would fall below
+        /// the base duration of the contest if the amount of minutes provided
+        /// is added to their Contest End Time.
+        /// </summary>
+        /// <param name="contestId">The id of the contest</param>
+        /// <param name="minutes">Amount of minutes to be added to the participant's contest end time. 
+        /// Amount can be negative</param>
+        /// <param name="contestStartTimeRangeStart">The lower bound against which participants' contest start time would be checked</param>
+        /// <param name="contestStartTimeRangeEnd">The upper bound against which participants' contest start time would be checked</param>
+        /// <returns>Returns participants whose contest duration would be reduced below
+        /// the base contest duration.</returns>
+        IQueryable<Participant> GetAllParticipantsWhoWouldBeReducedBelowDefaultContestDuration(
             int contestId,
             int minutes,
             DateTime contestStartTimeRangeStart,

--- a/Open Judge System/OJS.Services/Business/Participants/ParticipantsBusinessService.cs
+++ b/Open Judge System/OJS.Services/Business/Participants/ParticipantsBusinessService.cs
@@ -52,7 +52,7 @@
             return participant;
         }
 
-        public IQueryable<Participant> UpdateContestEndTimeForAllParticipantsByContestByParticipantContestStartTimeRangeAndTimeIntervalInMinutes(
+        public void UpdateContestEndTimeForAllParticipantsByContestByParticipantContestStartTimeRangeAndTimeIntervalInMinutes(
             int contestId,
             int minutes,
             DateTime contestStartTimeRangeStart,
@@ -78,10 +78,25 @@
                     minutes,
                     p.ContestEndTime)
                 });
+        }
 
-            var participantsInvalidForUpdate = participantsInTimeRange
-                .Where(p => SqlFunctions.DateAdd("minute", minutes, p.ContestEndTime) <
-                    SqlFunctions.DateAdd("minute", contestTotalDurationInMinutes, p.ContestStartTime));
+        public IQueryable<Participant> GetAllParticipantsWhoWouldBeReducedBelowDefaultContestDuration(
+            int contestId,
+            int minutes,
+            DateTime contestStartTimeRangeStart,
+            DateTime contestStartTimeRangeEnd)
+        {
+            var contest = this.contestsData.GetById(contestId);
+            var contestTotalDurationInMinutes = contest.Duration.Value.TotalMinutes;
+
+            var participantsInvalidForUpdate =
+                this.participantsData
+                    .GetAllOfficialInOnlineContestByContestAndContestStartTimeRange(
+                        contestId,
+                        contestStartTimeRangeStart,
+                        contestStartTimeRangeEnd)
+                    .Where(p => SqlFunctions.DateAdd("minute", minutes, p.ContestEndTime) <
+                                SqlFunctions.DateAdd("minute", contestTotalDurationInMinutes, p.ContestStartTime));            
 
             return participantsInvalidForUpdate;
         }

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ContestsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ContestsController.cs
@@ -364,16 +364,22 @@
                 return this.RedirectToAction<ContestsController>(c => c.Index());
             }
 
-            var notUpdatedUsersUsernames = 
-                this.participantsBusiness
-                    .UpdateContestEndTimeForAllParticipantsByContestByParticipantContestStartTimeRangeAndTimeIntervalInMinutes(
-                        model.ContesId, 
-                        model.TimeInMinutes,
-                        model.ParticipantsCreatedAfterDateTime.Value,
-                        model.ParticipantsCreatedBeforeDateTime.Value)
-                    .Select(u => u.User.UserName)
-                    .ToList();
-        
+            var notUpdatedUsersUsernames = this.participantsBusiness
+                .GetAllParticipantsWhoWouldBeReducedBelowDefaultContestDuration(
+                    model.ContesId,
+                    model.TimeInMinutes,
+                    model.ParticipantsCreatedAfterDateTime.Value,
+                    model.ParticipantsCreatedBeforeDateTime.Value)
+                .Select(u => u.User.UserName)
+                .ToList();
+
+            this.participantsBusiness
+                .UpdateContestEndTimeForAllParticipantsByContestByParticipantContestStartTimeRangeAndTimeIntervalInMinutes(
+                    model.ContesId,
+                    model.TimeInMinutes,
+                    model.ParticipantsCreatedAfterDateTime.Value,
+                    model.ParticipantsCreatedBeforeDateTime.Value);
+
             var minutesForDisplay = model.TimeInMinutes.ToString();
 
             var sb = new StringBuilder();


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/suls-issues/issues/3770 - Display correct users that won't be affected when subtracting time from Online Contests