### PR TITLE
Updated dot net framework version used in DotNetCoreCompileExecuteAndCheck strategy

### DIFF
--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/DotNetCoreCompileExecuteAndCheckExecutionStrategy.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/DotNetCoreCompileExecuteAndCheckExecutionStrategy.cs
@@ -16,7 +16,7 @@
 	            ""runtimeOptions"": {
                     ""framework"": {
                         ""name"": ""Microsoft.NETCore.App"",
-                        ""version"": ""2.0.0""
+                        ""version"": ""2.0.5""
                     }
                 }
             }";

--- a/Open Judge System/Workers/OJS.Workers.LocalWorker/App.config
+++ b/Open Judge System/Workers/OJS.Workers.LocalWorker/App.config
@@ -11,7 +11,7 @@
   <appSettings>
     <add key="CSharpCompilerPath" value="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\Roslyn\csc.exe" />
     <add key="CSharpDotNetCoreCompilerPath" value="C:\Program Files\dotnet\sdk\2.1.4\Roslyn\bincore\csc.dll" />
-    <add key="DotNetCoreSharedAssembliesPath" value="C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.0" />
+    <add key="DotNetCoreSharedAssembliesPath" value="C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.5" />
     <add key="CPlusPlusGccCompilerPath" value="C:\mingw-w64\mingw64\bin\g++.exe" />
     <add key="DotNetCompilerPath" value="C:\Program Files\dotnet\dotnet.exe" />
 	  <add key="NUnitConsoleRunnerPath" value="C:\NUnitConsole\nunit3-console.exe" />


### PR DESCRIPTION
Update version of framework used in DotNetCoreCompileExecuteAndCheckExecutionStrategy
Closes https://github.com/SoftUni-Internal/suls-issues/issues/3981