### PR TITLE
Fixed sending empty exam group (with no userIds) not to throw error

### DIFF
--- a/Open Judge System/OJS.Services/Business/ExamGroups/ExamGroupsBusinessService.cs
+++ b/Open Judge System/OJS.Services/Business/ExamGroups/ExamGroupsBusinessService.cs
@@ -61,7 +61,6 @@
                     }
 
                     examGroup.Users.Add(user);
-                    this.examGroupsData.Update(examGroup);
                 }
                 else
                 {
@@ -69,6 +68,8 @@
                         x => x.AddExternalUserByIdAndUser(examGroup.Id, userId));
                 }
             }
+
+            this.examGroupsData.Update(examGroup);
         }
 
         public void RemoveUsersByIdAndUserIds(int id, IEnumerable<string> userIds)

--- a/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
@@ -90,7 +90,7 @@
 
         private bool IsUsersExamGroupModelValid(UsersExamGroupModel model)
         {
-            var hasUsers = model.UserIds != null && model.UserIds.Any();
+            var hasUsers = model.UserIds?.Any() == true;
             var hasExamGroupId = model.ExamGroupInfoModel.Id != default(int);
             var hasAppId = !string.IsNullOrWhiteSpace(model.AppId);
             var hasRequiredNames = !string.IsNullOrWhiteSpace(model.ExamGroupInfoModel.ExamName) &&

--- a/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
@@ -90,7 +90,7 @@
 
         private bool IsUsersExamGroupModelValid(UsersExamGroupModel model)
         {
-            var hasUsers = model.UserIds.Any();
+            var hasUsers = model.UserIds != null && model.UserIds.Any();
             var hasExamGroupId = model.ExamGroupInfoModel.Id != default(int);
             var hasAppId = !string.IsNullOrWhiteSpace(model.AppId);
             var hasRequiredNames = !string.IsNullOrWhiteSpace(model.ExamGroupInfoModel.ExamName) &&

--- a/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
@@ -90,13 +90,13 @@
 
         private bool IsUsersExamGroupModelValid(UsersExamGroupModel model)
         {
-            var hasUsers = model.UserIds?.Any() == true;
+            var hasUsers = model.UserIds?.Any();
             var hasExamGroupId = model.ExamGroupInfoModel.Id != default(int);
             var hasAppId = !string.IsNullOrWhiteSpace(model.AppId);
             var hasRequiredNames = !string.IsNullOrWhiteSpace(model.ExamGroupInfoModel.ExamName) &&
                 !string.IsNullOrWhiteSpace(model.ExamGroupInfoModel.ExamGroupTrainingLabName);
 
-            return hasUsers && hasExamGroupId && hasAppId && hasRequiredNames;
+            return (hasUsers ?? false) && hasExamGroupId && hasAppId && hasRequiredNames;
         }
     }
 }

--- a/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
@@ -96,7 +96,9 @@
             var hasRequiredNames = !string.IsNullOrWhiteSpace(model.ExamGroupInfoModel.ExamName) &&
                 !string.IsNullOrWhiteSpace(model.ExamGroupInfoModel.ExamGroupTrainingLabName);
 
-            return (hasUsers ?? false) && hasExamGroupId && hasAppId && hasRequiredNames;
+            var isModelValid = (hasUsers ?? false) && hasExamGroupId && hasAppId && hasRequiredNames;
+
+            return isModelValid;
         }
     }
 }


### PR DESCRIPTION
Sending empty exam group from suls to Judge throws exception
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4083