### PR TITLE
Fixed Compete in Online contest with EndTime null not to throw exception in the View

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Shared/_ProblemsInProblemGroupGridTemplate.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Shared/_ProblemsInProblemGroupGridTemplate.cshtml
@@ -5,7 +5,7 @@
         .Name("ProblemsInProblemGroup_#=Id#")
         .Columns(columns =>
         {
-            columns.Bound(m => m.Id);
+            columns.Bound(m => m.Id).Hidden();
             columns.Bound(m => m.Name);
         })
         .ColumnMenu()

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Compete/Index.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Compete/Index.cshtml
@@ -134,7 +134,7 @@
             }
             else
             {
-                if (this.ViewBag.IsUserAdminOrLecturer ?? false)
+                if ((this.ViewBag.IsUserAdminOrLecturer ?? false) && contestIsCompete)
                 {
                     var contestRemainingTimeFormat = remainingTimeFormat.Replace(
                         Resource.Remaining_time,


### PR DESCRIPTION
Compete throws exception for admin/lecturer if Online Contest End time is null
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4087