### PR TITLE
Added password length validation for Create/Edit of Contest

### DIFF
--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/Contests/ViewModels/ContestAdministration.Designer.cs
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/Contests/ViewModels/ContestAdministration.Designer.cs
@@ -188,6 +188,15 @@ namespace Resources.Areas.Administration.Contests.ViewModels {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The password cannot be longer than {1} symbols.
+        /// </summary>
+        public static string Password_max_length {
+            get {
+                return ResourceManager.GetString("Password_max_length", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Practice end.
         /// </summary>
         public static string Practice_end_time {

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/Contests/ViewModels/ContestAdministration.bg.resx
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/Contests/ViewModels/ContestAdministration.bg.resx
@@ -159,6 +159,9 @@
   <data name="Order_required" xml:space="preserve">
     <value>Подредбата е задължителна!</value>
   </data>
+  <data name="Password_max_length" xml:space="preserve">
+    <value>Паролата не може да бъде по-дълга от {1} символа</value>
+  </data>
   <data name="Practice_end_time" xml:space="preserve">
     <value>Край упражнение</value>
   </data>

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/Contests/ViewModels/ContestAdministration.resx
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/Contests/ViewModels/ContestAdministration.resx
@@ -159,6 +159,9 @@
   <data name="Order_required" xml:space="preserve">
     <value>The order is required!</value>
   </data>
+  <data name="Password_max_length" xml:space="preserve">
+    <value>The password cannot be longer than {1} symbols</value>
+  </data>
   <data name="Practice_end_time" xml:space="preserve">
     <value>Practice end</value>
   </data>

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/ViewModels/Contest/ContestAdministrationViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/ViewModels/Contest/ContestAdministrationViewModel.cs
@@ -121,11 +121,13 @@
 
         [DatabaseProperty]
         [Display(Name = "Contest_password", ResourceType = typeof(Resource))]
+        [StringLength(GlobalConstants.ContestPasswordMaxLength)]
         [UIHint("SingleLineText")]
         public string ContestPassword { get; set; }
 
         [DatabaseProperty]
         [Display(Name = "Practice_password", ResourceType = typeof(Resource))]
+        [StringLength(GlobalConstants.ContestPasswordMaxLength)]
         [UIHint("SingleLineText")]
         public string PracticePassword { get; set; }
 

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/ViewModels/Contest/ContestAdministrationViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/ViewModels/Contest/ContestAdministrationViewModel.cs
@@ -121,13 +121,19 @@
 
         [DatabaseProperty]
         [Display(Name = "Contest_password", ResourceType = typeof(Resource))]
-        [StringLength(GlobalConstants.ContestPasswordMaxLength)]
+        [MaxLength(
+            GlobalConstants.ContestPasswordMaxLength,
+            ErrorMessageResourceName = "Password_max_length",
+            ErrorMessageResourceType = typeof(Resource))]
         [UIHint("SingleLineText")]
         public string ContestPassword { get; set; }
 
         [DatabaseProperty]
         [Display(Name = "Practice_password", ResourceType = typeof(Resource))]
-        [StringLength(GlobalConstants.ContestPasswordMaxLength)]
+        [MaxLength(
+            GlobalConstants.ContestPasswordMaxLength,
+            ErrorMessageResourceName = "Password_max_length",
+            ErrorMessageResourceType = typeof(Resource))]
         [UIHint("SingleLineText")]
         public string PracticePassword { get; set; }
 


### PR DESCRIPTION
Validate Contest Password Length in ViewModel on Contest Creation
Closes https://github.com/SoftUni-Internal/suls-issues/issues/3663