### PR TITLE
Updated reference of EF BulkInsert ext package

### DIFF
--- a/Open Judge System/Data/OJS.Data/OJS.Data.csproj
+++ b/Open Judge System/Data/OJS.Data/OJS.Data.csproj
@@ -46,9 +46,8 @@
       <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EntityFramework.BulkInsert, Version=6.0.2.8, Culture=neutral, PublicKeyToken=630a17433349cb76, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Web\OJS.Web\Bin\EntityFramework.BulkInsert.dll</HintPath>
+    <Reference Include="EntityFramework.BulkInsert, Version=6.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.BulkInsert-ef6-ext.6.0.3.1\lib\net45\EntityFramework.BulkInsert.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.Extended, Version=6.0.0.0, Culture=neutral, PublicKeyToken=05b7e29bdd433584, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EntityFramework.Extended.6.1.0.168\lib\net45\EntityFramework.Extended.dll</HintPath>


### PR DESCRIPTION
EntityFramework.BulkInsert-ef6-ext not referenced correctly, resulting in build failure
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4259