### PR TITLE
Fixed check to ensure lecturers which are also admins can see all Exam groups

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ExamGroupsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ExamGroupsController.cs
@@ -45,7 +45,7 @@
         {
             var examGroups = this.examGroupsData.GetAll();
 
-            if (this.User.IsLecturer())
+            if (this.User.IsLecturer() && !this.User.IsAdmin())
             {
                 examGroups = this.examGroupsData.GetAllByLecturer(this.UserProfile.Id);
             }


### PR DESCRIPTION
Lecturers which are also admins cannot see all ExamGroups
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4283