### PR TITLE
Refactored CSharpProject strategies to remove EnsureNuGetPackageBuildImports target

### DIFF
--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpAspProjectTestsExecutionStrategy.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpAspProjectTestsExecutionStrategy.cs
@@ -2,22 +2,19 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Xml;
 
     using Microsoft.Build.Evaluation;
 
     using OJS.Common.Models;
+    using OJS.Workers.ExecutionStrategies.Extensions;
 
     public class CSharpAspProjectTestsExecutionStrategy : CSharpProjectTestsExecutionStrategy
     {
         protected const string MoqAssemblyReference =
             "Moq, Version=4.7.8.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL";
+
         protected const string CastleCoreAssemblyReference =
             @"Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc";
-        protected const string NuGetXmlNodeXPath = @"//msns:Target[@Name='EnsureNuGetPackageBuildImports']";
-        protected const string VsToolsXmlNodeXPath = @"//msns:Import[@Project='$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets']";
-        protected const string MicrosoftCsProjXmlNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
 
         public CSharpAspProjectTestsExecutionStrategy(
             string nUnitConsoleRunnerPath,
@@ -30,38 +27,11 @@
 
         protected override void CorrectProjectReferences(IEnumerable<TestContext> tests, Project project)
         {
-            this.AddProjectReferences(project, MoqAssemblyReference, CastleCoreAssemblyReference);
+            project.AddReferences(MoqAssemblyReference, CastleCoreAssemblyReference);
 
             base.CorrectProjectReferences(tests, project);
 
-            bool nuGetPackageImportsTarget = project.Targets.ContainsKey("EnsureNuGetPackageBuildImports");
-            if (nuGetPackageImportsTarget)
-            {
-                this.RemoveXmlNodeFromCsProj(project.FullPath, NuGetXmlNodeXPath);
-            }
-
-            var vsToolsImport =
-                project.Imports.Any(i =>
-                    i.ImportingElement.Project ==
-                    "$(VSToolsPath)\\WebApplications\\Microsoft.WebApplication.targets");
-
-            if (vsToolsImport)
-            {
-                this.RemoveXmlNodeFromCsProj(project.FullPath, VsToolsXmlNodeXPath);
-            }
-        }
-
-        private void RemoveXmlNodeFromCsProj(string csprojPath, string xpathExpression)
-        {
-            XmlDocument csprojXml = new XmlDocument();
-            csprojXml.Load(csprojPath);
-            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(csprojXml.NameTable);
-            namespaceManager.AddNamespace("msns", MicrosoftCsProjXmlNamespace);
-
-            XmlNode rootNode = csprojXml.DocumentElement;
-            var targetNode = rootNode.SelectSingleNode(xpathExpression, namespaceManager);
-            rootNode.RemoveChild(targetNode);
-            csprojXml.Save(csprojPath);
+            project.RemoveVsToolsImport();
         }
     }
 }

--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpUnitTestsExecutionStrategy.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpUnitTestsExecutionStrategy.cs
@@ -13,11 +13,14 @@
     using OJS.Workers.Checkers;
     using OJS.Workers.Common;
     using OJS.Workers.Compilers;
+    using OJS.Workers.ExecutionStrategies.Extensions;
     using OJS.Workers.ExecutionStrategies.Helpers;
     using OJS.Workers.Executors;
 
     public class CSharpUnitTestsExecutionStrategy : CSharpProjectTestsExecutionStrategy
     {
+        private const string NUnitFrameworkPackageName = "nunit.framework";
+
         public CSharpUnitTestsExecutionStrategy(
             string nUnitConsoleRunnerPath,
             Func<CompilerType, string> getCompilerPathFunc,
@@ -42,8 +45,6 @@
             this.SaveSetupFixture(project.DirectoryPath);
 
             this.CorrectProjectReferences(project);
-            project.Save(csProjFilePath);
-            project.ProjectCollection.UnloadAllProjects();
 
             var executor = new RestrictedProcessExecutor(this.BaseTimeUsed, this.BaseMemoryUsed);
             var checker = Checker.CreateChecker(
@@ -160,7 +161,7 @@
         {
             project.AddItem("Compile", $"{SetupFixtureFileName}{GlobalConstants.CSharpFileExtension}");
 
-            this.EnsureAssemblyNameIsCorrect(project);
+            project.EnsureAssemblyNameIsCorrect();
 
             // Remove the first Project Reference (this should be the reference to the tested project)
             var projectReference = project.GetItems("ProjectReference").FirstOrDefault();
@@ -172,27 +173,18 @@
             project.AddItem("Compile", UnitTestStrategiesHelper.TestedCodeFileName);
             project.SetProperty("OutputType", "Library");
 
-            var nUnitPrevReference = project.Items.FirstOrDefault(x => x.EvaluatedInclude.Contains("nunit.framework"));
-            if (nUnitPrevReference != null)
-            {
-                project.RemoveItem(nUnitPrevReference);
-            }
+            project.RemoveItemByName(NUnitFrameworkPackageName);
 
-            // Add our NUnit Reference, if private is false, the .dll will not be copied and the tests will not run
-            var nUnitMetaData = new Dictionary<string, string>();
-            nUnitMetaData.Add("SpecificVersion", "False");
-            nUnitMetaData.Add("Private", "True");
-            project.AddItem("Reference", NUnitReference, nUnitMetaData);
+            // Add our NUnit Reference
+            project.AddReferences(NUnitReference);
 
             // If we use NUnit we don't really need the VSTT, it will save us copying of the .dll
-            var vsTestFrameworkReference = project.Items
-                .FirstOrDefault(x =>
-                    x.EvaluatedInclude.Contains("Microsoft.VisualStudio.QualityTools.UnitTestFramework"));
+            project.RemoveItemByName(VsttPackageName);
 
-            if (vsTestFrameworkReference != null)
-            {
-                project.RemoveItem(vsTestFrameworkReference);
-            }
+            project.Save(project.FullPath);
+            project.ProjectCollection.UnloadAllProjects();
+
+            project.RemoveNuGetPackageImportsTarget();
         }
     }
 }

--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/Extensions/CSharpProjectExtensions.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/Extensions/CSharpProjectExtensions.cs
@@ -1,0 +1,103 @@
+﻿namespace OJS.Workers.ExecutionStrategies.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Xml;
+
+    using Microsoft.Build.Evaluation;
+
+    internal static class CSharpProjectExtensions
+    {
+        private const string MicrosoftCsProjXmlNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
+        private const string NuGetXmlNodeXPath = @"//msns:Target[@Name='EnsureNuGetPackageBuildImports']";
+        private const string VsToolsXmlNodeXPath = @"//msns:Import[@Project='$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets']";
+
+        public static void RemoveNuGetPackageImportsTarget(this Project project)
+        {
+            if (project.Targets.ContainsKey("EnsureNuGetPackageBuildImports"))
+            {
+                RemoveXmlNodeFromCsProj(project.FullPath, NuGetXmlNodeXPath);
+            }
+        }
+
+        public static void RemoveVsToolsImport(this Project project)
+        {
+            var vsToolsImport = project.Imports.Any(i =>
+                i.ImportingElement.Project ==
+                    "$(VSToolsPath)\\WebApplications\\Microsoft.WebApplication.targets");
+
+            if (vsToolsImport)
+            {
+                RemoveXmlNodeFromCsProj(project.FullPath, VsToolsXmlNodeXPath);
+            }
+        }
+
+        public static void RemoveItemByName(this Project project, string itemName)
+        {
+            var item = project.Items.FirstOrDefault(pi =>
+                pi.EvaluatedInclude.Contains(itemName));
+
+            if (item != null)
+            {
+                project.RemoveItem(item);
+            }
+        }
+
+        public static void AddReferences(this Project project, params string[] references)
+        {
+            RemoveExistingReferences(project, references);
+
+            foreach (var reference in references)
+            {
+                var referenceMetaData = new Dictionary<string, string>
+                {
+                    { "SpecificVersion", "False" },
+                    { "Private", "True" }
+                };
+
+                project.AddItem("Reference", reference, referenceMetaData);
+            }
+        }
+
+        public static void EnsureAssemblyNameIsCorrect(this Project project)
+        {
+            var assemblyNameProperty = project.AllEvaluatedProperties.FirstOrDefault(x => x.Name == "AssemblyName");
+            if (assemblyNameProperty == null)
+            {
+                throw new ArgumentException("Project file does not contain Assembly Name property!");
+            }
+
+            var csProjFullpath = project.FullPath;
+            var projectName = Path.GetFileNameWithoutExtension(csProjFullpath);
+            project.SetProperty("AssemblyName", projectName);
+        }
+
+        private static void RemoveExistingReferences(Project project, IEnumerable<string> references)
+        {
+            foreach (var reference in references)
+            {
+                var referenceName = reference.Substring(0, reference.IndexOf(","));
+                var existingReference = project.Items.FirstOrDefault(x => x.EvaluatedInclude.Contains(referenceName));
+                if (existingReference != null)
+                {
+                    project.RemoveItem(existingReference);
+                }
+            }
+        }
+
+        private static void RemoveXmlNodeFromCsProj(string csprojPath, string xpathExpression)
+        {
+            var csprojXml = new XmlDocument();
+            csprojXml.Load(csprojPath);
+            var namespaceManager = new XmlNamespaceManager(csprojXml.NameTable);
+            namespaceManager.AddNamespace("msns", MicrosoftCsProjXmlNamespace);
+
+            XmlNode rootNode = csprojXml.DocumentElement;
+            var targetNode = rootNode.SelectSingleNode(xpathExpression, namespaceManager);
+            rootNode.RemoveChild(targetNode);
+            csprojXml.Save(csprojPath);
+        }
+    }
+}

--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/OJS.Workers.ExecutionStrategies.csproj
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/OJS.Workers.ExecutionStrategies.csproj
@@ -95,6 +95,7 @@
     <Compile Include="DotNetCoreProjectExecutionStrategy.cs" />
     <Compile Include="DotNetCoreProjectTestsExecutionStrategy.cs" />
     <Compile Include="ExecutionStrategy.cs" />
+    <Compile Include="Extensions\CSharpProjectExtensions.cs" />
     <Compile Include="Helpers\DotNetCoreStrategiesHelper.cs" />
     <Compile Include="Helpers\UnitTestStrategiesHelper.cs" />
     <Compile Include="IExecutionStrategy.cs" />


### PR DESCRIPTION
CSharpProject related strategies should delete EnsureNuGetPackageBuildImports target from user csproj
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4321