### PR TITLE
Fixed contest name with '#' to be escaped when displaying it in kendo toolbar

### DIFF
--- a/Open Judge System/Web/OJS.Web/App_Start/BundleConfig.cs
+++ b/Open Judge System/Web/OJS.Web/App_Start/BundleConfig.cs
@@ -51,7 +51,8 @@
             bundles.Add(new ScriptBundle("~/bundles/problems-index").Include(
                 "~/Scripts/Administration/Problems/problems-index.js",
                 "~/Scripts/Administration/Contests/contest-search.js",
-                "~/Scripts/Administration/Contests/contests-helper.js"));
+                "~/Scripts/Administration/Contests/contests-helper.js",
+                "~/Scripts/Helpers/kendo-helper.js"));
 
             bundles.Add(new ScriptBundle("~/bundles/problem-groups-index").Include(
                 "~/Scripts/Administration/ProblemGroups/problem-groups-index.js",

--- a/Open Judge System/Web/OJS.Web/OJS.Web.csproj
+++ b/Open Judge System/Web/OJS.Web/OJS.Web.csproj
@@ -2524,6 +2524,7 @@
     <None Include="Properties\PublishProfiles\Dev Suls Judge System.pubxml" />
     <None Include="Properties\PublishProfiles\File System.pubxml" />
     <None Include="Properties\PublishProfiles\Suls Judge System.pubxml" />
+    <Content Include="Scripts\Helpers\kendo-helper.js" />
     <Content Include="Scripts\Helpers\validations.js" />
     <Content Include="Scripts\KendoUI\2014.3.1411\cultures\kendo.culture.bg.js" />
     <Content Include="Scripts\KendoUI\2014.3.1411\cultures\kendo.culture.en-GB.js" />

--- a/Open Judge System/Web/OJS.Web/Scripts/Administration/Problems/problems-index.js
+++ b/Open Judge System/Web/OJS.Web/Scripts/Administration/Problems/problems-index.js
@@ -31,6 +31,7 @@ function initializeGrid(contestId) {
     var sendSubmissionsActionName;
 
     $('#status').show();
+    $('#problems-grid').empty();
 
     $.get('/Administration/KendoRemoteData/GetContestCompeteOrPracticeActionName/' + contestId, function (data) {
         sendSubmissionsActionName = data;
@@ -40,8 +41,8 @@ function initializeGrid(contestId) {
         }).then(function () {
             var contestName = response[0].ContestName;
             var urlContestName = convertContestnameToUrlName(contestName);
+            var escapedContestName = escapeSpecialSymbols(contestName);
             $('#status').hide();
-            $('#problems-grid').html('');
             $('#problems-grid').kendoGrid({
                 dataSource: new kendo.data.DataSource({
                     data: response
@@ -57,7 +58,7 @@ function initializeGrid(contestId) {
                     '<a href="/Contests/' + sendSubmissionsActionName + '/Index/' + contestId +
                     '" class="btn btn-sm btn-primary">Изпрати решение/я</a>' +
                     '<a href="/Contests/' + contestId + '/' + urlContestName +
-                    '" class="pull-right kendo-grid-link text-bold">' + contestName + '</a>'
+                    '" class="pull-right kendo-grid-link text-bold">' + escapedContestName + '</a>'
                 }],
                 columns: [
                     { field: 'Name', title: 'Име', template: '<a href="/Administration/Problems/Details/#= Id #" class="kendo-grid-link text-bold">#=Name#</a>'},

--- a/Open Judge System/Web/OJS.Web/Scripts/Helpers/kendo-helper.js
+++ b/Open Judge System/Web/OJS.Web/Scripts/Helpers/kendo-helper.js
@@ -1,0 +1,3 @@
+﻿function escapeSpecialSymbols (text) {
+    return text.replace('#', '\\#');
+}


### PR DESCRIPTION
Problems not loading in contest containing '#' in its name
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4541