### PR TITLE
Fixed checks when firing bg job for removing users from exam group

### DIFF
--- a/Open Judge System/OJS.Services/Data/ExamGroups/ExamGroupsDataService.cs
+++ b/Open Judge System/OJS.Services/Data/ExamGroups/ExamGroupsDataService.cs
@@ -33,7 +33,7 @@
                     eg.ExternalExamGroupId == externalId &&
                     eg.ExternalAppId == appId);
 
-        public int? GetIdByExternalIdAndAppId(int? externalId, string appId) =>
+        public int GetIdByExternalIdAndAppId(int? externalId, string appId) =>
             this.examGroups
                 .All()
                 .Where(eg => eg.ExternalExamGroupId == externalId && eg.ExternalAppId == appId)

--- a/Open Judge System/OJS.Services/Data/ExamGroups/IExamGroupsDataService.cs
+++ b/Open Judge System/OJS.Services/Data/ExamGroups/IExamGroupsDataService.cs
@@ -15,7 +15,7 @@
         
         ExamGroup GetByExternalIdAndAppId(int? externalId, string appId);
 
-        int? GetIdByExternalIdAndAppId(int? externalId, string appId);
+        int GetIdByExternalIdAndAppId(int? externalId, string appId);
 
         int? GetContestIdById(int id);
 

--- a/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Api/Controllers/ExamGroupsController.cs
@@ -60,10 +60,10 @@
             var examGroupId = this.examGroupsData
                 .GetIdByExternalIdAndAppId(externalExamGroup.Id, model.AppId);
 
-            if (examGroupId.HasValue)
+            if (examGroupId != default(int))
             {
                 this.backgroundJobs.AddFireAndForgetJob<IExamGroupsBusinessService>(
-                    x => x.AddUsersByIdAndUserIds(examGroupId.Value, model.UserIds));
+                    x => x.AddUsersByIdAndUserIds(examGroupId, model.UserIds));
             }
 
             return this.Json(true);
@@ -79,10 +79,10 @@
             var examGroupId = this.examGroupsData
                 .GetIdByExternalIdAndAppId(model.ExamGroupInfoModel.Id, model.AppId);
 
-            if (examGroupId.HasValue)
+            if (examGroupId != default(int))
             {
                 this.backgroundJobs.AddFireAndForgetJob<IExamGroupsBusinessService>(
-                    x => x.RemoveUsersByIdAndUserIds(examGroupId.Value, model.UserIds));
+                    x => x.RemoveUsersByIdAndUserIds(examGroupId, model.UserIds));
             }
 
             return this.Json(true);


### PR DESCRIPTION
Background job for removing users from exam group fires and fails if group does not exist
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4537