### PR TITLE
Changed problem groups order in online contest to start from 1

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ContestsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Controllers/ContestsController.cs
@@ -551,7 +551,7 @@
 
         private void AddProblemGroupsToContest(Contest contest, int problemGroupsCount)
         {
-            for (var i = 0; i < problemGroupsCount; i++)
+            for (var i = 1; i <= problemGroupsCount; i++)
             {
                 contest.ProblemGroups.Add(new ProblemGroup
                 {


### PR DESCRIPTION
Problem groups count starting from zero
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4212