### PR TITLE
Improved error catching in CSharpProjectTestsExecutionStrategy

### DIFF
--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
@@ -241,7 +241,7 @@
 
                 if (errorsByFiles.ContainsKey(fileName))
                 {
-                    errorsByFiles[fileName] += Environment.NewLine + output;
+                    errorsByFiles[fileName] += ". " + output;
                 }
                 else
                 {

--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
@@ -59,7 +59,7 @@
 
         // Extracts error/failure messages and the class which threw it
         protected static readonly string ErrorMessageRegex =
-            @"(\d+\) (?:Failed|Error)\s:\s(.*)\.(.*))\r?\n((?:.*)\r?\n(?:.*))";
+            @"((\d+-\d+\)|\d+\)) (?:Failed|Error)\s:\s(.*)\.(.*))\r?\n((?:.*)\r?\n(?:.*))";
 
         public CSharpProjectTestsExecutionStrategy(
             Func<CompilerType, string> getCompilerPathFunc,
@@ -235,9 +235,18 @@
             foreach (Match error in errors)
             {
                 var failedAssert = error.Groups[1].Value;
-                var cause = error.Groups[4].Value;
-                var fileName = error.Groups[2].Value;
-                errorsByFiles.Add(fileName, $"{failedAssert} : {cause}".ToSingleLine());
+                var cause = error.Groups[5].Value;
+                var fileName = error.Groups[3].Value;
+                var output = $"{failedAssert} : {cause}".ToSingleLine();
+
+                if (errorsByFiles.ContainsKey(fileName))
+                {
+                    errorsByFiles[fileName] += Environment.NewLine + output;
+                }
+                else
+                {
+                    errorsByFiles.Add(fileName, output);
+                }
             }
 
             return errorsByFiles;

--- a/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
+++ b/Open Judge System/Workers/OJS.Workers.ExecutionStrategies/CSharpProjectTestsExecutionStrategy.cs
@@ -59,7 +59,7 @@
 
         // Extracts error/failure messages and the class which threw it
         protected static readonly string ErrorMessageRegex =
-            @"((\d+-\d+\)|\d+\)) (?:Failed|Error)\s:\s(.*)\.(.*))\r?\n((?:.*)\r?\n(?:.*))";
+            @"((?:\d+|\d+-\d+)\) (?:Failed|Error)\s:\s(.*)\.(.*))\r?\n((?:.*)\r?\n(?:.*))";
 
         public CSharpProjectTestsExecutionStrategy(
             Func<CompilerType, string> getCompilerPathFunc,
@@ -235,8 +235,8 @@
             foreach (Match error in errors)
             {
                 var failedAssert = error.Groups[1].Value;
-                var cause = error.Groups[5].Value;
-                var fileName = error.Groups[3].Value;
+                var cause = error.Groups[4].Value;
+                var fileName = error.Groups[2].Value;
                 var output = $"{failedAssert} : {cause}".ToSingleLine();
 
                 if (errorsByFiles.ContainsKey(fileName))


### PR DESCRIPTION
.NET Core Project Tests strategy throws exception, instead of failing tests
Closes https://github.com/SoftUni-Internal/suls-issues/issues/4673