### PR TITLE
Changed old workaround for fixed bug in DotNetZip package

### DIFF
--- a/Open Judge System/Web/OJS.Web.Common/ZippedTestManipulator/ZippedTestsParser.cs
+++ b/Open Judge System/Web/OJS.Web.Common/ZippedTestManipulator/ZippedTestsParser.cs
@@ -111,15 +111,17 @@
 
         public static string ExtractFileFromStream(ZipEntry entry)
         {
-            var reader = new MemoryStream();
-            entry.Extract(reader);
-            reader = new MemoryStream(reader.ToArray());
+            using (var memoryStream = new MemoryStream())
+            {
+                entry.Extract(memoryStream);
 
-            var streamReader = new StreamReader(reader);
-
-            var text = streamReader.ReadToEnd();
-            reader.Dispose();
-            return text;
+                memoryStream.Position = 0;
+                using (var streamReader = new StreamReader(memoryStream))
+                {
+                    var text = streamReader.ReadToEnd();
+                    return text;
+                }
+            }
         }
 
         public static bool AreTestsParsedCorrectly(TestsParseResult tests)


### PR DESCRIPTION
Check ZipTestParser's Extract method for memory leaks
Closes https://github.com/SoftUni-Internal/suls-issues/issues/2010