### PR TITLE
Update Judge .NET Core 3.0

### DIFF
--- a/Open Judge System/LocalWorker/OJS.LocalWorker/App.config
+++ b/Open Judge System/LocalWorker/OJS.LocalWorker/App.config
@@ -11,8 +11,8 @@
   <appSettings>
     <add key="MonitoringServiceExecutablePath" value="C:\OpenJudgeSystem\Open Judge System\LocalWorker\OJS.LocalWorkerMonitoring\bin\Debug\OJS.LocalWorkerMonitoring.exe" />
     <add key="CSharpCompilerPath" value="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\Roslyn\csc.exe" />
-    <add key="CSharpDotNetCoreCompilerPath" value="C:\Program Files\dotnet\sdk\2.1.4\Roslyn\bincore\csc.dll" />
-    <add key="DotNetCoreSharedAssembliesPath" value="C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.5" />
+    <add key="CSharpDotNetCoreCompilerPath" value="C:\Program Files\dotnet\sdk\3.0.100\Roslyn\bincore\csc.dll" />
+    <add key="DotNetCoreSharedAssembliesPath" value="C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.0.0" />
     <add key="CPlusPlusGccCompilerPath" value="C:\mingw-w64\mingw64\bin\g++.exe" />
     <add key="DotNetCompilerPath" value="C:\Program Files\dotnet\dotnet.exe" />
 	  <add key="NUnitConsoleRunnerPath" value="C:\NUnitConsole\nunit3-console.exe" />
@@ -91,7 +91,7 @@
     <add key="MsBuildCompilerProcessExitTimeOutMultiplier" value="2" />
     <add key="MsBuildLibraryCompilerProcessExitTimeOutMultiplier" value="2" />
     <add key="SolidityCompilerProcessExitTimeOutMultiplier" value="1" />
-    <add key="DotNetCoreRuntimeVersion" value="2.0.5" />
+    <add key="DotNetCoreRuntimeVersion" value="3.0.0" />
   </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />


### PR DESCRIPTION
Update Judge Version .NET Core 3.0 - closes https://github.com/SoftUni-Internal/suls-issues/issues/5411

In order for this to work, .NET Core 3.0 must be installed on the machine running the judge service at:
(default location)
_"C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.0.0\"_
and the CSharp .NET Core 3.0 compiler must be installed at:
(default location)
_"C:\Program Files\dotnet\sdk\3.0.100\Roslyn\bincore\csc.dll"_