### PR TITLE
Added c++ zip strategy compiler output in result

### DIFF
--- a/Open Judge System/LocalWorker/OJS.LocalWorker/App.config
+++ b/Open Judge System/LocalWorker/OJS.LocalWorker/App.config
@@ -81,7 +81,7 @@
     <add key="SolidityBaseTimeUsedInMilliseconds" value="3000" />
     <add key="SolidityBaseMemoryUsedInBytes" value="0" />
     <add key="CPlusPlusCompilerProcessExitTimeOutMultiplier" value="1" />
-    <add key="CPlusPlusZipCompilerProcessExitTimeOutMultiplier" value="1" />
+    <add key="CPlusPlusZipCompilerProcessExitTimeOutMultiplier" value="3" />
     <add key="CSharpCompilerProcessExitTimeOutMultiplier" value="2" />
     <add key="CSharpDotNetCoreCompilerProcessExitTimeOutMultiplier" value="1" />
     <add key="DotNetCompilerProcessExitTimeOutMultiplier" value="4" />


### PR DESCRIPTION
Compiler output missing from C++ zip strategy
https://github.com/SoftUni-Internal/suls-issues/issues/5674

Increase C++ zip strategy compiler exit timeout
closes https://github.com/SoftUni-Internal/suls-issues/issues/5675