### PR TITLE
Display last executed on the UI

### DIFF
--- a/Open Judge System/Data/OJS.Data.Models/Submission.cs
+++ b/Open Judge System/Data/OJS.Data.Models/Submission.cs
@@ -97,6 +97,8 @@
 
         public bool Processed { get; set; }
 
+        public DateTime? StartedExecutionOn { get; set; }
+
         public string ProcessingComment { get; set; }
 
         /// <summary>

--- a/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
+++ b/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
@@ -82,6 +82,7 @@
         public override void BeforeExecute()
         {
             this.submission.ProcessingComment = null;
+            this.submission.StartedExecutionOn = DateTime.Now;
             this.testRunsData.DeleteBySubmission(this.submission.Id);
         }
 

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.Designer.cs
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.Designer.cs
@@ -19,7 +19,7 @@ namespace Resources.Areas.Administration {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class AdministrationGeneral {
@@ -201,6 +201,15 @@ namespace Resources.Areas.Administration {
         public static string Remove {
             get {
                 return ResourceManager.GetString("Remove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Started execution on.
+        /// </summary>
+        public static string Started_execution_on {
+            get {
+                return ResourceManager.GetString("Started_execution_on", resourceCulture);
             }
         }
     }

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.bg.resx
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.bg.resx
@@ -165,4 +165,7 @@
   <data name="Remove" xml:space="preserve">
     <value>Премахни</value>
   </data>
+  <data name="Started_execution_on" xml:space="preserve">
+    <value>Последно стартиране на изпълнение</value>
+  </data>
 </root>

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.resx
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.resx
@@ -165,4 +165,7 @@
   <data name="Remove" xml:space="preserve">
     <value>Remove</value>
   </data>
+  <data name="Started_execution_on" xml:space="preserve">
+    <value>Started execution on</value>
+  </data>
 </root>

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Submissions/SubmissionDetailsViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Submissions/SubmissionDetailsViewModel.cs
@@ -34,7 +34,8 @@
                 ShowResults = submission.Problem.ShowResults,
                 ShowDetailedFeedback = submission.Problem.ShowDetailedFeedback,
                 TotalTests = submission.Problem.Tests.Count,
-                TestRuns = submission.TestRuns.AsQueryable().Select(TestRunDetailsViewModel.FromTestRun)
+                TestRuns = submission.TestRuns.AsQueryable().Select(TestRunDetailsViewModel.FromTestRun),
+                StartedExecutionOn = submission.StartedExecutionOn
             };
 
         public int Id { get; set; }
@@ -92,5 +93,7 @@
         public string ContentAsString => this.IsBinaryFile ? "Binary file." : this.Content.Decompress();
 
         public bool HasTestRuns => this.TestRuns.Any();
+
+        public DateTime? StartedExecutionOn { get; set; }
     }
 }

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
@@ -301,7 +301,7 @@ else
 
                         JavaScriptSerializer serializer = new JavaScriptSerializer();
                         serializer.MaxJsonLength = Int32.MaxValue;
-                        
+
                         <script>
                             $(function () {
                                 var diffContainer = document.getElementById('diff-@testResult.Id');
@@ -350,6 +350,7 @@ else
 @if (Model.UserHasAdminPermission)
 {
     <p>@AdministrationResource.Modified_on: @Model.ModifiedOn</p>
+    <p>@AdministrationResource.Started_execution_on: @Model.StartedExecutionOn</p>
 }
 
 <script>


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/138


Added a new column "ExecutionStartedOn" in the submission table.
In the UI inside the details of the submission, below the modified on should be displayed the date of the last test.
Upon retesting the date should be updated.