### PR TITLE
Update Softuni.Judge.Common package version

### DIFF
--- a/Common/OJS.Common/OJS.Common.csproj
+++ b/Common/OJS.Common/OJS.Common.csproj
@@ -9,7 +9,7 @@
       <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
       <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.1" />
       <PackageReference Include="NPOI" Version="2.5.5" />
-      <PackageReference Include="SoftUni.Judge.Common" Version="1.0.10" />
+      <PackageReference Include="SoftUni.Judge.Common" Version="1.0.11" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes: https://github.com/SoftUni-Internal/exam-systems-issues/issues/613

Update Softuni.Judge.Common package version to 1.0.11 - the latest version that contains JavaHibernate