### PR TITLE
Ordering contests by OrderBy

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
@@ -2,9 +2,9 @@ import { ContestStatus, FilterType, SortType } from './contest-types';
 
 const DEFAULT_PROBLEM_RESULTS_TAKE_CONTESTS_PAGE = 4;
 const { Status: DEFAULT_FILTER_TYPE } = FilterType;
-const { All: DEFAULT_STATUS_FILTER_TYPE } = ContestStatus;
+const { Active: DEFAULT_STATUS_FILTER_TYPE } = ContestStatus;
 const { Sort: DEFAULT_SORT_FILTER_TYPE } = FilterType;
-const { StartDate: DEFAULT_SORT_TYPE } = SortType;
+const { OrderBy: DEFAULT_SORT_TYPE } = SortType;
 
 enum SubmissionResultType {
     CorrectAnswer = 'correctanswer',

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
@@ -2,7 +2,7 @@ import { ContestStatus, FilterType, SortType } from './contest-types';
 
 const DEFAULT_PROBLEM_RESULTS_TAKE_CONTESTS_PAGE = 4;
 const { Status: DEFAULT_FILTER_TYPE } = FilterType;
-const { Active: DEFAULT_STATUS_FILTER_TYPE } = ContestStatus;
+const { All: DEFAULT_STATUS_FILTER_TYPE } = ContestStatus;
 const { Sort: DEFAULT_SORT_FILTER_TYPE } = FilterType;
 const { OrderBy: DEFAULT_SORT_TYPE } = SortType;
 

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/contest-sorting-utils.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/contest-sorting-utils.ts
@@ -7,6 +7,7 @@ const generateSortingStrategy = (() => {
         { name: SortType.Name, value: SortType.Name },
         { name: SortType.StartDate, value: SortType.StartDate },
         { name: SortType.EndDate, value: SortType.EndDate },
+        { name: SortType.OrderBy, value: SortType.OrderBy },
     );
 
     return () => result;

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/contest-types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/contest-types.ts
@@ -11,6 +11,7 @@ enum SortType {
     Name = 'Name',
     StartDate = 'StartDate',
     EndDate = 'EndDate',
+    OrderBy = 'OrderBy',
 }
 
 type FilterSortType = FilterType | SortType;

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-sorting/ContestSorting.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-sorting/ContestSorting.tsx
@@ -71,7 +71,7 @@ const ContestSorting = ({ onSortClick }: IContestSortingProps) => {
                         Sorting
                     </Heading>
                     <List
-                      values={possibleSortingTypes.filter((sort) => sort.name !== 'OrderBy')}
+                      values={possibleSortingTypes)}
                       itemFunc={renderSortingItemFunc}
                       orientation={Orientation.horizontal}
                       className={styles.sortTypesList}

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-sorting/ContestSorting.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-sorting/ContestSorting.tsx
@@ -69,7 +69,7 @@ const ContestSorting = ({ onSortClick }: IContestSortingProps) => {
                         Sorting
                     </Heading>
                     <List
-                      values={possibleSortingTypes}
+                      values={possibleSortingTypes.filter((sort) => sort.name !== 'OrderBy')}
                       itemFunc={renderSortingItemFunc}
                       orientation={Orientation.horizontal}
                       className={styles.sortTypesList}

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-sorting/ContestSorting.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-sorting/ContestSorting.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable */
+/*
 import React, { useCallback } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';
@@ -81,4 +83,6 @@ const ContestSorting = ({ onSortClick }: IContestSortingProps) => {
     );
 };
 
-export default ContestSorting;
+export default ContestSorting; */
+
+export {};

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contests-filters/ContestFilters.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contests-filters/ContestFilters.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';
 
-import { FilterType, IFilter, ISort } from '../../../common/contest-types';
+import { FilterType, IFilter /* ISort */ } from '../../../common/contest-types';
 import { groupByType } from '../../../common/filter-utils';
 import { useContestCategories } from '../../../hooks/use-contest-categories';
 import { useCategoriesBreadcrumbs } from '../../../hooks/use-contest-categories-breadcrumb';
@@ -13,7 +13,6 @@ import Button, { ButtonSize, ButtonType } from '../../guidelines/buttons/Button'
 import List from '../../guidelines/lists/List';
 import ContestCategories from '../contest-categories/ContestCategories';
 import ContestFilter from '../contest-filter/ContestFilter';
-import ContestSorting from '../contest-sorting/ContestSorting';
 
 import styles from './ContestFilters.module.scss';
 
@@ -45,7 +44,7 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
     const {
         state: { possibleFilters },
         actions: {
-            toggleParam,
+            // toggleParam,
             clearFilters,
             clearSorts,
         },
@@ -53,10 +52,10 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
 
     const { actions: { clearBreadcrumb } } = useCategoriesBreadcrumbs();
 
-    const handleSortClick = useCallback(
-        (sorting: ISort) => toggleParam(sorting),
-        [ toggleParam ],
-    );
+    // const handleSortClick = useCallback(
+    //     (sorting: ISort) => toggleParam(sorting),
+    //     [ toggleParam ],
+    // );
 
     const handleFilterClick = useCallback(
         (filterId: number) => {
@@ -177,7 +176,9 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
               defaultSelected={defaultSelected}
               setStrategyFilters={setFilteredStrategyFilters}
             />
-            <ContestSorting onSortClick={handleSortClick} />
+            {/* Commented out because displaying sorting menu to
+            the user is no longer a wanted feature
+            <ContestSorting onSortClick={handleSortClick} /> */}
             <List
               values={filtersGroups}
               itemFunc={renderFilter}

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/home-contests/ContestsList.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/home-contests/ContestsList.tsx
@@ -59,8 +59,8 @@ const ContestsList = ({
     );
 
     const link = useMemo(
-        () => `/contests?status=${contestStatusIndex}`,
-        [ contestStatusIndex ],
+        () => `/contests?status=${contestStatus}`,
+        [ contestStatus ],
     );
 
     return (

--- a/Services/UI/OJS.Services.Ui.Data/Implementations/ContestsDataService.cs
+++ b/Services/UI/OJS.Services.Ui.Data/Implementations/ContestsDataService.cs
@@ -167,34 +167,42 @@ public class ContestsDataService : DataService<Contest>, IContestsDataService
                 c.Id == id &&
                 c.ExamGroups.Any(eg => eg.UsersInExamGroups.Any(u => u.UserId == userId)));
 
+    // After removing the sorting menu for the user, we are using OrderBy as default sorting value
+    //Logic for Name, StartDate and EndDate is not used anymore therefore it is commented out
     private static IQueryable<Contest> Sort(
         IQueryable<Contest> contests,
         ContestSortType? sorting,
         int categoriesCount)
     {
-        if (sorting == ContestSortType.StartDate)
-        {
-            return contests
-                .OrderBy(c => c.StartTime)
-                .ThenBy(c => c.PracticeStartTime)
-                .ThenBy(c => c.Name);
-        }
+        // if (sorting == ContestSortType.StartDate)
+        // {
+        //     return contests
+        //         .OrderBy(c => c.StartTime)
+        //         .ThenBy(c => c.PracticeStartTime)
+        //         .ThenBy(c => c.Name);
+        // }
+        //
+        // if (sorting == ContestSortType.EndDate)
+        // {
+        //     return contests
+        //         .OrderBy(c => c.EndTime)
+        //         .ThenBy(c => c.PracticeEndTime)
+        //         .ThenBy(c => c.Name);
+        // }
+        //
+        // if (sorting == ContestSortType.Name)
+        // {
+        //     return contests
+        //         .OrderBy(c => c.Name)
+        //         .ThenBy(c => c.StartTime)
+        //         .ThenBy(c => c.PracticeStartTime);
+        // }
 
-        if (sorting == ContestSortType.EndDate)
-        {
-            return contests
-                .OrderBy(c => c.EndTime)
-                .ThenBy(c => c.PracticeEndTime)
-                .ThenBy(c => c.Name);
-        }
-
-        if (sorting == ContestSortType.Name)
-        {
-            return contests
-                .OrderBy(c => c.Name)
-                .ThenBy(c => c.StartTime)
-                .ThenBy(c => c.PracticeStartTime);
-        }
+        // By checking the number of categories we can determine if the contest is a parent or a child contest
+        //based on this we display the contests differently
+        // 0 categories - main contest page display the contest which have the LEAST time left
+        // 1 category - child contest and we order the by the order by property of the category
+        // > 1 categories - we first order them by the Contest.Category's OrderBy and then by the Contest's OrderBy
 
         if (sorting == ContestSortType.OrderBy)
         {
@@ -211,8 +219,8 @@ public class ContestsDataService : DataService<Contest>, IContestsDataService
                 default:
                     return contests
                             .OrderBy(c => c.Category == null ? int.MaxValue : c.Category.OrderBy)
-                            .ThenByDescending(c => c.EndTime)
-                            .ThenByDescending(c => c.StartTime);
+                            .ThenBy(c => c.OrderBy)
+                            .ThenByDescending(c => c.EndTime);
             }
         }
 

--- a/Services/UI/OJS.Services.Ui.Data/Implementations/ContestsDataService.cs
+++ b/Services/UI/OJS.Services.Ui.Data/Implementations/ContestsDataService.cs
@@ -202,18 +202,17 @@ public class ContestsDataService : DataService<Contest>, IContestsDataService
             {
                 case 0:
                     return contests
-                        .OrderByDescending(c => c.StartTime)
-                        .ThenBy(c => c.EndTime);
+                        .OrderByDescending(c => c.EndTime);
                 case 1:
                     return contests
                             .OrderBy(c => c.OrderBy)
-                            .ThenByDescending(c => c.StartTime)
-                            .ThenBy(c => c.EndTime);
+                            .ThenByDescending(c => c.EndTime)
+                            .ThenByDescending(c => c.StartTime);
                 default:
                     return contests
                             .OrderBy(c => c.Category == null ? int.MaxValue : c.Category.OrderBy)
-                            .ThenByDescending(c => c.StartTime)
-                            .ThenBy(c => c.EndTime);
+                            .ThenByDescending(c => c.EndTime)
+                            .ThenByDescending(c => c.StartTime);
             }
         }
 

--- a/Services/UI/OJS.Services.Ui.Data/Implementations/ContestsDataService.cs
+++ b/Services/UI/OJS.Services.Ui.Data/Implementations/ContestsDataService.cs
@@ -200,7 +200,7 @@ public class ContestsDataService : DataService<Contest>, IContestsDataService
 
         // By checking the number of categories we can determine if the contest is a parent or a child contest
         //based on this we display the contests differently
-        // 0 categories - main contest page display the contest which have the LEAST time left
+        // 0 categories - main contest page displays the contest which have the LEAST time left
         // 1 category - child contest and we order the by the order by property of the category
         // > 1 categories - we first order them by the Contest.Category's OrderBy and then by the Contest's OrderBy
 
@@ -210,17 +210,20 @@ public class ContestsDataService : DataService<Contest>, IContestsDataService
             {
                 case 0:
                     return contests
-                        .OrderByDescending(c => c.EndTime);
+                        .OrderBy(c => c.EndTime.HasValue && c.EndTime.Value < DateTime.UtcNow ? 2 :
+                            c.EndTime.HasValue ? 1 : 3)
+                        .ThenBy(c => c.EndTime);
+
                 case 1:
                     return contests
                             .OrderBy(c => c.OrderBy)
                             .ThenByDescending(c => c.EndTime)
-                            .ThenByDescending(c => c.StartTime);
+                            .ThenByDescending(c => c.PracticeEndTime);
                 default:
                     return contests
-                            .OrderBy(c => c.Category == null ? int.MaxValue : c.Category.OrderBy)
-                            .ThenBy(c => c.OrderBy)
-                            .ThenByDescending(c => c.EndTime);
+                        .OrderBy(c => c.Category == null ? int.MaxValue : c.Category.OrderBy)
+                        .ThenBy(c => c.OrderBy)
+                        .ThenByDescending(c => c.EndTime);
             }
         }
 

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestSortType.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestSortType.cs
@@ -5,4 +5,5 @@ public enum ContestSortType
     StartDate = 0,
     EndDate = 1,
     Name = 2,
+    OrderBy = 3,
 }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/745
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/749

**Summary of the changes made**:
1. Adding OrderBy to ContestSortType and additional logic in ContestDataService for sorting contests based on the ContestCategoryId.Count -Linq queries to get the contest whose end time is the soonest
2. Adjusting default constants to 'OrderBy' (sorting contests) and 'Active' (filtering the status) and adding OrderBy to sorted-related components
3. Fixing 'See all' button in ContestList (displayed on home page)
4. Commenting out ContestSorting component and it's usage 
