### PR TITLE
Add solution skeleton to submission type in problem

### DIFF
--- a/Data/OJS.Data.Models/SubmissionTypeInProblem.cs
+++ b/Data/OJS.Data.Models/SubmissionTypeInProblem.cs
@@ -12,5 +12,10 @@ namespace OJS.Data.Models
         public int ProblemId { get; set; }
 
         public virtual Problem Problem { get; set; } = null!;
+
+        /// <summary>
+        /// Gets or sets a predefined skeleton for the task and strategy.
+        /// </summary>
+        public byte[] SolutionSkeleton { get; set; } = default!;
     }
 }

--- a/Servers/Administration/OJS.Servers.Administration/wwwroot/js/mvc-grid-form.js
+++ b/Servers/Administration/OJS.Servers.Administration/wwwroot/js/mvc-grid-form.js
@@ -1,9 +1,10 @@
-$(document).ready(function() {
-    $(":checkbox").on('click', function(event) {
-        if (event.target.value === "True") {
-            event.target.value = "False"
+/* eslint-disable */
+$(document).ready(() => {
+    $(':checkbox').on('click', (event) => {
+        if (event.target.value === 'True') {
+            event.target.value = 'False';
         } else {
-            event.target.value = "True"
+            event.target.value = 'True';
         }
     });
 
@@ -11,20 +12,33 @@ $(document).ready(function() {
 
     forms.find('select').select2();
 
-    forms.submit(function(ev) {
+    forms.submit((ev) => {
         const form = $(ev.target);
 
         form.find('select').prop('disabled', false);
 
-        form.find('fieldset').each(function (ev, fs) {
+        form.find('fieldset').each((ev, fs) => {
             const selectedCheckboxes = $(fs).find('input[type=checkbox]').toArray();
-            const result = selectedCheckboxes.map(x => ({
-                name: $(x).data("name"),
-                value: $(x).data("value"),
-                isChecked: $(x).is(":checked")}));
+
+            const getExpandElement = (checkbox) => {
+                const expandElement = $(`#${$(checkbox).attr('expand')} :input`)[0];
+
+                return expandElement && expandElement.name && expandElement.value
+                    ? { name: expandElement.name, value: expandElement.value }
+                    : null;
+            };
+
+            const result = selectedCheckboxes.map((x) => ({
+                name: $(x).data('name'),
+                value: $(x).data('value'),
+                isChecked: $(x).is(':checked'),
+                expand: getExpandElement(x),
+            }));
+
             const input = $(`<input name="${fs.name}">`)
-                .attr('type','hidden')
+                .attr('type', 'hidden')
                 .val(JSON.stringify(result));
+
             form.append(input);
         });
 

--- a/Services/Administration/OJS.Services.Administration.Business/Extensions/AdminActionContextExtensions.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Extensions/AdminActionContextExtensions.cs
@@ -21,9 +21,9 @@ public static class AdminActionContextExtensions
     public static ProblemGroupType? GetProblemGroupType(this AdminActionContext actionContext)
         => actionContext.EntityDict[AdditionalFormFields.ProblemGroupType.ToString()].ToEnum<ProblemGroupType>();
 
-    public static IEnumerable<CheckboxFormControlViewModel> GetSubmissionTypes(this AdminActionContext actionContext)
+    public static IEnumerable<ExpandableMultiChoiceCheckBoxFormControlViewModel> GetSubmissionTypes(this AdminActionContext actionContext)
         => actionContext.EntityDict[AdditionalFormFields.SubmissionTypes.ToString()]
-            .FromJson<IEnumerable<CheckboxFormControlViewModel>>();
+            .FromJson<IEnumerable<ExpandableMultiChoiceCheckBoxFormControlViewModel>>();
 
     public static int? GetEntityIdOrDefault<TEntity>(this AdminActionContext actionContext)
         where TEntity : class

--- a/Services/Common/OJS.Services.Common/Implementations/SubmissionsDistributorCommunicationService.cs
+++ b/Services/Common/OJS.Services.Common/Implementations/SubmissionsDistributorCommunicationService.cs
@@ -137,7 +137,11 @@ namespace OJS.Services.Common.Implementations
                     CheckerType = checkerType,
                     CheckerParameter = submission.Problem.Checker?.Parameter,
                     Tests = tests,
-                    TaskSkeleton = submission.Problem.SolutionSkeleton,
+                    TaskSkeleton = submission.Problem
+                        .SubmissionTypesInProblems
+                        .Where(x => x.SubmissionTypeId == submission.SubmissionTypeId)
+                        .Select(x => x.SolutionSkeleton)
+                        .FirstOrDefault(),
                 },
             };
 


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/342

Linked pull requests from another repos (if any):

**Summary of the changes made**:
1. Remove solution skeleton field from admin create problem page
2. Add expandable text area for solution skeleton to each submission type on create problem page in administration
