### PR TITLE
Fixing refresh of Contests Page redirecting to 404 page if filters with strategy are applied

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contests/ContestsPage.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contests/ContestsPage.tsx
@@ -47,11 +47,18 @@ const ContestsPage = () => {
     const { state: { categoriesFlat }, actions: { load: loadCategories } } = useContestCategories();
     const navigate = useNavigate();
     const { state: params } = useUrlParams();
-    const { state: { strategies } } = useContestStrategyFilters();
+    const { state: { strategies }, actions: { load } } = useContestStrategyFilters();
 
     useEffect(
         () => {
             initiateGetAllContestsQuery();
+
+            if (isEmpty(strategies)) {
+                (async () => {
+                    await load();
+                })();
+            }
+
             if (!isEmpty(categoriesFlat)) {
                 return;
             }
@@ -60,7 +67,7 @@ const ContestsPage = () => {
                 await loadCategories();
             })();
         },
-        [ initiateGetAllContestsQuery, categoriesFlat, loadCategories ],
+        [ initiateGetAllContestsQuery, categoriesFlat, loadCategories, load, strategies ],
     );
 
     const filtersArray = useMemo(


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/773

**Summary of the changes made**:
1. Adding additional check in useEffect to see if strategies are loaded and if not to load them
