### PR TITLE
Disabling submission timer and submit button when user uploads a file with a wrong file extension

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
@@ -1,6 +1,7 @@
 import { ContestStatus, FilterType, SortType } from './contest-types';
 
 const DEFAULT_PROBLEM_RESULTS_TAKE_CONTESTS_PAGE = 4;
+const FileValidationError = 'Invalid file extension.';
 const { Status: DEFAULT_FILTER_TYPE } = FilterType;
 const { All: DEFAULT_STATUS_FILTER_TYPE } = ContestStatus;
 const { Sort: DEFAULT_SORT_FILTER_TYPE } = FilterType;
@@ -24,7 +25,6 @@ enum ContestResultType {
 enum FileType {
     Blob = 'blob',
 }
-const FileValidationError = 'Invalid file extension.';
 
 export {
     DEFAULT_PROBLEM_RESULTS_TAKE_CONTESTS_PAGE,

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
@@ -24,10 +24,7 @@ enum ContestResultType {
 enum FileType {
     Blob = 'blob',
 }
-
-enum FileValidationError {
-    InvalidFileExtensionError = 'Invalid file extension.',
-}
+const FileValidationError = 'Invalid file extension.';
 
 export {
     DEFAULT_PROBLEM_RESULTS_TAKE_CONTESTS_PAGE,

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/constants.ts
@@ -25,6 +25,10 @@ enum FileType {
     Blob = 'blob',
 }
 
+enum FileValidationError {
+    InvalidFileExtensionError = 'Invalid file extension.',
+}
+
 export {
     DEFAULT_PROBLEM_RESULTS_TAKE_CONTESTS_PAGE,
     DEFAULT_FILTER_TYPE,
@@ -35,4 +39,5 @@ export {
     ContestParticipationType,
     ContestResultType,
     FileType,
+    FileValidationError,
 };

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
@@ -223,11 +223,6 @@ const SubmissionBox = () => {
             const { detail } = error;
 
             return (
-                // <AlertBox
-                //   message={detail}
-                //   type={AlertBoxType.error}
-                //   onClose={() => closeErrorMessage(problemId.toString())}
-                // />
                 renderAlertBox(detail, AlertBoxType.error, () => closeErrorMessage(problemId.toString()))
             );
         },

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
@@ -191,14 +191,14 @@ const SubmissionBox = () => {
     }, [ handleOnSubmit, showSubmissionLimitTimer, isSubmitAllowed, invalidExtensionError ]);
 
     const renderAlertBox = useCallback(
-        (messageText : string, errorType: AlertBoxType, onCloseFunc : () => void) => (
+        (messageText : string, problemId : number) => (
             <AlertBox
               message={messageText}
-              type={errorType}
-              onClose={() => onCloseFunc()}
+              type={AlertBoxType.error}
+              onClose={() => closeErrorMessage(problemId.toString())}
             />
         ),
-        [],
+        [ closeErrorMessage ],
     );
 
     const renderSubmitMessage = useCallback(
@@ -209,9 +209,7 @@ const SubmissionBox = () => {
             }
 
             if (invalidExtensionError) {
-                return (
-                    renderAlertBox(invalidExtensionError, AlertBoxType.error, () => closeErrorMessage(problemId.toString()))
-                );
+                return renderAlertBox(invalidExtensionError, problemId);
             }
 
             const { [problemId.toString()]: error } = problemSubmissionErrors;
@@ -222,11 +220,9 @@ const SubmissionBox = () => {
 
             const { detail } = error;
 
-            return (
-                renderAlertBox(detail, AlertBoxType.error, () => closeErrorMessage(problemId.toString()))
-            );
+            return renderAlertBox(detail, problemId);
         },
-        [ closeErrorMessage, currentProblem, problemSubmissionErrors, invalidExtensionError, renderAlertBox ],
+        [ currentProblem, problemSubmissionErrors, invalidExtensionError, renderAlertBox ],
     );
 
     useEffect(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
@@ -190,6 +190,17 @@ const SubmissionBox = () => {
         );
     }, [ handleOnSubmit, showSubmissionLimitTimer, isSubmitAllowed, invalidExtensionError ]);
 
+    const renderAlertBox = useCallback(
+        (messageText : string, errorType: AlertBoxType, onCloseFunc : () => void) => (
+            <AlertBox
+              message={messageText}
+              type={errorType}
+              onClose={() => onCloseFunc()}
+            />
+        ),
+        [],
+    );
+
     const renderSubmitMessage = useCallback(
         () => {
             const { id: problemId } = currentProblem || {};
@@ -199,11 +210,7 @@ const SubmissionBox = () => {
 
             if (invalidExtensionError) {
                 return (
-                    <AlertBox
-                      message={invalidExtensionError}
-                      type={AlertBoxType.error}
-                      onClose={() => closeErrorMessage(problemId.toString())}
-                    />
+                    renderAlertBox(invalidExtensionError, AlertBoxType.error, () => closeErrorMessage(problemId.toString()))
                 );
             }
 
@@ -216,14 +223,15 @@ const SubmissionBox = () => {
             const { detail } = error;
 
             return (
-                <AlertBox
-                  message={detail}
-                  type={AlertBoxType.error}
-                  onClose={() => closeErrorMessage(problemId.toString())}
-                />
+                // <AlertBox
+                //   message={detail}
+                //   type={AlertBoxType.error}
+                //   onClose={() => closeErrorMessage(problemId.toString())}
+                // />
+                renderAlertBox(detail, AlertBoxType.error, () => closeErrorMessage(problemId.toString()))
             );
         },
-        [ closeErrorMessage, currentProblem, problemSubmissionErrors, invalidExtensionError ],
+        [ closeErrorMessage, currentProblem, problemSubmissionErrors, invalidExtensionError, renderAlertBox ],
     );
 
     useEffect(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
@@ -20,6 +20,7 @@ import styles from './SubmissionBox.module.scss';
 
 const SubmissionBox = () => {
     const [ submitLimit, setSubmitLimit ] = useState<number>(0);
+    const [ invalidExtensionError, setInvalidExtensionError ] = useState<string | null>(null);
     const {
         state: {
             contest,
@@ -176,7 +177,7 @@ const SubmissionBox = () => {
     );
 
     const renderSubmitBtn = useCallback(() => {
-        const state = !isSubmitAllowed || showSubmissionLimitTimer
+        const state = !isSubmitAllowed || showSubmissionLimitTimer || invalidExtensionError
             ? ButtonState.disabled
             : ButtonState.enabled;
 
@@ -187,13 +188,23 @@ const SubmissionBox = () => {
               onClick={handleOnSubmit}
             />
         );
-    }, [ handleOnSubmit, showSubmissionLimitTimer, isSubmitAllowed ]);
+    }, [ handleOnSubmit, showSubmissionLimitTimer, isSubmitAllowed, invalidExtensionError ]);
 
     const renderSubmitMessage = useCallback(
         () => {
             const { id: problemId } = currentProblem || {};
             if (isNil(problemId)) {
                 return null;
+            }
+
+            if (invalidExtensionError) {
+                return (
+                    <AlertBox
+                      message={invalidExtensionError}
+                      type={AlertBoxType.error}
+                      onClose={() => closeErrorMessage(problemId.toString())}
+                    />
+                );
             }
 
             const { [problemId.toString()]: error } = problemSubmissionErrors;
@@ -212,7 +223,7 @@ const SubmissionBox = () => {
                 />
             );
         },
-        [ closeErrorMessage, currentProblem, problemSubmissionErrors ],
+        [ closeErrorMessage, currentProblem, problemSubmissionErrors, invalidExtensionError ],
     );
 
     useEffect(
@@ -260,6 +271,8 @@ const SubmissionBox = () => {
                               ? null
                               : submissionCode as File}
                           problemId={problemId}
+                          allowedFileExtensions={allowedFileExtensions}
+                          onInvalidFileExtension={setInvalidExtensionError}
                         />
                         <p className={styles.fileSubmissionDetailsParagraph}>
                             Allowed file extensions:
@@ -279,7 +292,7 @@ const SubmissionBox = () => {
                 />
             );
         },
-        [ handleCodeChanged, selectedSubmissionType, submissionCode, currentProblem ],
+        [ handleCodeChanged, selectedSubmissionType, submissionCode, currentProblem, setInvalidExtensionError ],
     );
 
     const renderSubmissionBox = useCallback(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
@@ -9,9 +9,13 @@ import styles from './FileUploader.module.scss';
 interface IFileUploaderProps {
     file?: File | null;
     problemId?: number;
+    allowedFileExtensions: string[];
+    onInvalidFileExtension: (error: string | null) => void;
 }
 
-const FileUploader = ({ file, problemId }: IFileUploaderProps) => {
+const invalidExtentionErrorMessage = 'Invalid file extension.';
+
+const FileUploader = ({ file, problemId, allowedFileExtensions, onInvalidFileExtension }: IFileUploaderProps) => {
     const hiddenFileInput = useRef<HTMLInputElement | null>(null);
     const { actions: { updateSubmissionCode } } = useSubmissions();
     const [ internalFile, setInternalFile ] = useState<File | null>(null);
@@ -42,6 +46,15 @@ const FileUploader = ({ file, problemId }: IFileUploaderProps) => {
                 return;
             }
 
+            const uploadedFile = eventTarget[0];
+            const extension = uploadedFile.name.split('.').pop();
+
+            if (allowedFileExtensions && !allowedFileExtensions.includes(extension) && !isNil(onInvalidFileExtension)) {
+                onInvalidFileExtension(invalidExtentionErrorMessage);
+            } else {
+                onInvalidFileExtension(null);
+            }
+
             updateSubmissionCode(eventTarget[0]);
             setInternalFile(eventTarget[0]);
             setInternalProblemId(problemId);
@@ -49,7 +62,7 @@ const FileUploader = ({ file, problemId }: IFileUploaderProps) => {
             // eslint-disable-next-line no-param-reassign
             event.target.value = null;
         },
-        [ updateSubmissionCode, problemId ],
+        [ updateSubmissionCode, problemId, allowedFileExtensions, onInvalidFileExtension ],
     );
 
     return (

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
@@ -49,7 +49,7 @@ const FileUploader = ({ file, problemId, allowedFileExtensions, onInvalidFileExt
             const extension = uploadedFile.name.split('.').pop();
 
             if (allowedFileExtensions && !allowedFileExtensions.includes(extension) && !isNil(onInvalidFileExtension)) {
-                onInvalidFileExtension(FileValidationError.InvalidFileExtensionError);
+                onInvalidFileExtension(FileValidationError);
             } else {
                 onInvalidFileExtension(null);
             }

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
@@ -48,7 +48,7 @@ const FileUploader = ({ file, problemId, allowedFileExtensions, onInvalidFileExt
             const uploadedFile = eventTarget[0];
             const extension = uploadedFile.name.split('.').pop();
 
-            if (allowedFileExtensions && !allowedFileExtensions.includes(extension) && !isNil(onInvalidFileExtension)) {
+            if (allowedFileExtensions && !allowedFileExtensions.includes(extension)) {
                 onInvalidFileExtension(FileValidationError);
             } else {
                 onInvalidFileExtension(null);

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import isNil from 'lodash/isNil';
 
+import { FileValidationError } from '../../common/constants';
 import { useSubmissions } from '../../hooks/submissions/use-submissions';
 import Button, { ButtonSize, ButtonType } from '../guidelines/buttons/Button';
 
@@ -12,8 +13,6 @@ interface IFileUploaderProps {
     allowedFileExtensions: string[];
     onInvalidFileExtension: (error: string | null) => void;
 }
-
-const invalidExtensionErrorMessage = 'Invalid file extension.';
 
 const FileUploader = ({ file, problemId, allowedFileExtensions, onInvalidFileExtension }: IFileUploaderProps) => {
     const hiddenFileInput = useRef<HTMLInputElement | null>(null);
@@ -50,7 +49,7 @@ const FileUploader = ({ file, problemId, allowedFileExtensions, onInvalidFileExt
             const extension = uploadedFile.name.split('.').pop();
 
             if (allowedFileExtensions && !allowedFileExtensions.includes(extension) && !isNil(onInvalidFileExtension)) {
-                onInvalidFileExtension(invalidExtensionErrorMessage);
+                onInvalidFileExtension(FileValidationError.InvalidFileExtensionError);
             } else {
                 onInvalidFileExtension(null);
             }

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/file-uploader/FileUploader.tsx
@@ -13,7 +13,7 @@ interface IFileUploaderProps {
     onInvalidFileExtension: (error: string | null) => void;
 }
 
-const invalidExtentionErrorMessage = 'Invalid file extension.';
+const invalidExtensionErrorMessage = 'Invalid file extension.';
 
 const FileUploader = ({ file, problemId, allowedFileExtensions, onInvalidFileExtension }: IFileUploaderProps) => {
     const hiddenFileInput = useRef<HTMLInputElement | null>(null);
@@ -50,7 +50,7 @@ const FileUploader = ({ file, problemId, allowedFileExtensions, onInvalidFileExt
             const extension = uploadedFile.name.split('.').pop();
 
             if (allowedFileExtensions && !allowedFileExtensions.includes(extension) && !isNil(onInvalidFileExtension)) {
-                onInvalidFileExtension(invalidExtentionErrorMessage);
+                onInvalidFileExtension(invalidExtensionErrorMessage);
             } else {
                 onInvalidFileExtension(null);
             }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/747

**Summary of the changes made**:
1. Adding invalidExtensionError state variable in SubmissionBox. It passes down allowedFileExtensions and setInvalidError method to the FileUploader.tsx 
2. FileUploader checks the extension of the file and sets the error to null/ the invalid extension message. 
3. Submit button is disabled if invalidExtensionError is not null
