### PR TITLE
Completed execution on and Contest load page fixes

### DIFF
--- a/Open Judge System/Data/OJS.Data.Models/Submission.cs
+++ b/Open Judge System/Data/OJS.Data.Models/Submission.cs
@@ -101,6 +101,8 @@
 
         public DateTime? StartedExecutionOn { get; set; }
 
+        public DateTime? CompletedExecutionOn { get; set; }
+
         public string ProcessingComment { get; set; }
 
         /// <summary>

--- a/Open Judge System/Data/OJS.Data/Migrations/DefaultMigrationConfiguration.cs
+++ b/Open Judge System/Data/OJS.Data/Migrations/DefaultMigrationConfiguration.cs
@@ -21,7 +21,19 @@
 
         protected override void Seed(OjsDbContext context)
         {
-            this.SeedSettings(context);
+            this.SeedSettings(context, new HashSet<Setting>
+            {
+                new Setting
+                {
+                    Name = GlobalConstants.MaximumFileSizeDbName,
+                    Value = GlobalConstants.OneMegaByteInBytes.ToString()
+                },
+                new Setting
+                {
+                    Name = GlobalConstants.RemoteWorkers,
+                    Value = GlobalConstants.RemoteWorkersCount.ToString()
+                }
+            });
 
             if (context.Roles.Any())
             {
@@ -1170,18 +1182,17 @@
                 });
         }
 
-        private void SeedSettings(OjsDbContext context)
+        private void SeedSettings(OjsDbContext context, IEnumerable<Setting> settings)
         {
-            if (context.Settings.Any(s => s.Name == GlobalConstants.MaximumFileSizeDbName))
+            foreach (var setting in settings)
             {
-                return;
-            }
+                if (context.Settings.Any(s => s.Name == setting.Name))
+                {
+                    continue;
+                }
 
-            context.Settings.Add(new Setting
-            {
-                Name = GlobalConstants.MaximumFileSizeDbName,
-                Value = GlobalConstants.OneMegaByteInBytes.ToString()
-            });
+                context.Settings.Add(setting);
+            }
 
             context.SaveChanges();
         }

--- a/Open Judge System/Data/OJS.Data/Migrations/DefaultMigrationConfiguration.cs
+++ b/Open Judge System/Data/OJS.Data/Migrations/DefaultMigrationConfiguration.cs
@@ -32,6 +32,11 @@
                 {
                     Name = GlobalConstants.RemoteWorkers,
                     Value = GlobalConstants.RemoteWorkersCount.ToString()
+                },
+                new Setting
+                {
+                    Name = GlobalConstants.MaxAllowedTimeForSubmissionCompletion,
+                    Value = GlobalConstants.MaxAllowedTimeForSubmissionCompletionInSecs.ToString()
                 }
             });
 

--- a/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
+++ b/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
@@ -84,7 +84,6 @@
         {
             this.submission.ProcessingComment = null;
             this.submission.ExceptionType = ExceptionType.None;
-            this.submission.StartedExecutionOn = DateTime.Now;
             this.submission.CompilerComment = null;
             this.submission.ExecutionComment = null;
             this.testRunsData.DeleteBySubmission(this.submission.Id);
@@ -162,8 +161,10 @@
                 this.submission.TestRuns.Add(testRun);
             }
 
+            this.submission.StartedExecutionOn = executionResult.StartedExecutionOn;
+            this.submission.CompletedExecutionOn = executionResult.CompletedExecutionOn;
+            
             this.submissionsData.Update(this.submission);
-
             this.UpdateResults();
         }
 
@@ -277,7 +278,6 @@
             try
             {
                 this.submission.Processed = true;
-                this.submission.CompletedExecutionOn = DateTime.Now;
                 this.submissionForProcessing.Processed = true;
                 this.submissionForProcessing.Processing = false;
 

--- a/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
+++ b/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
@@ -277,6 +277,7 @@
             try
             {
                 this.submission.Processed = true;
+                this.submission.CompletedExecutionOn = DateTime.Now;
                 this.submissionForProcessing.Processed = true;
                 this.submissionForProcessing.Processing = false;
 

--- a/Open Judge System/OJS.Common/GlobalConstants.cs
+++ b/Open Judge System/OJS.Common/GlobalConstants.cs
@@ -138,5 +138,8 @@
 
         public static readonly string RemoteWorkers = "Remote_Workers_Count";
         public static readonly int RemoteWorkersCount = 36;
+
+        public const string MaxAllowedTimeForSubmissionCompletion = "Max_allowed_time_for_submission_completion_InSecs";
+        public static readonly int MaxAllowedTimeForSubmissionCompletionInSecs = 200;
     }
 }

--- a/Open Judge System/OJS.Common/GlobalConstants.cs
+++ b/Open Judge System/OJS.Common/GlobalConstants.cs
@@ -139,7 +139,7 @@
         public static readonly string RemoteWorkers = "Remote_Workers_Count";
         public static readonly int RemoteWorkersCount = 36;
 
-        public const string MaxAllowedTimeForSubmissionCompletion = "Max_allowed_time_for_submission_completion_InSecs";
+        public static readonly string MaxAllowedTimeForSubmissionCompletion = "Max_allowed_time_for_submission_completion_InSecs";
         public static readonly int MaxAllowedTimeForSubmissionCompletionInSecs = 200;
     }
 }

--- a/Open Judge System/OJS.Common/GlobalConstants.cs
+++ b/Open Judge System/OJS.Common/GlobalConstants.cs
@@ -48,7 +48,7 @@
         public const string AdministratorRoleName = "Administrator";
 
         public const string AdministrationAreaName = "Administration";
-        
+
         public const string AdministratorUserName = "judgeadmin";
         public const string AdministratorEmail = "judgeadmin@softuni.bg";
 
@@ -130,10 +130,13 @@
 
         // Date and time formats
         public const string DefaultDateTimeFormatString = "{0:dd/MM/yyyy HH:mm}";
-        
+
         // Settings DB name constants
         public const string MaximumFileSizeDbName = "Maximum_Resource_File_Size";
 
         public static readonly string[] ParticipationStatisticsFileSubmissionsAllowedExtensions = { ".java", ".cs", ".py", ".js", ".cpp", ".h" };
+
+        public static readonly string RemoteWorkers = "Remote_Workers_Count";
+        public static readonly int RemoteWorkersCount = 36;
     }
 }

--- a/Open Judge System/Services/OJS.Services/Business/Contests/ContestsBusinessService.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/ContestsBusinessService.cs
@@ -194,12 +194,15 @@
                                             StartedExecutionOn = s.StartedExecutionOn,
                                             ModifiedOn = s.ModifiedOn,
                                             CreatedOn = s.CreatedOn,
+                                            CompletedExecutionOn = s.CompletedExecutionOn,
                                         }))
                                     .ToList();
 
             if (contestSubmissions.Any(s => s.StartedExecutionOn.HasValue))
             {
-                return (int)contestSubmissions.Where(s => s.StartedExecutionOn.HasValue).Average(s => (s.ModifiedOn.Value - s.StartedExecutionOn.Value).TotalSeconds);
+                return contestSubmissions.Any(s => s.CompletedExecutionOn.HasValue)
+                    ? (int)contestSubmissions.Where(s => s.StartedExecutionOn.HasValue).Average(s => (s.CompletedExecutionOn.Value - s.StartedExecutionOn.Value).TotalSeconds)
+                    : (int)contestSubmissions.Where(s => s.StartedExecutionOn.HasValue).Average(s => (s.ModifiedOn.Value - s.StartedExecutionOn.Value).TotalSeconds);
             }
             else
             {

--- a/Open Judge System/Services/OJS.Services/Business/Contests/ContestsBusinessService.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/ContestsBusinessService.cs
@@ -216,7 +216,8 @@
 
             if (maxAllowedSubmissionCompletionTime.HasValue)
             {
-                submissionsRunTimeSecondsList.Where(s => s <= maxAllowedSubmissionCompletionTime.Value).ToList();
+                submissionsRunTimeSecondsList =
+                    submissionsRunTimeSecondsList.Where(s => s <= maxAllowedSubmissionCompletionTime.Value).ToList();
             }
 
             if (submissionsRunTimeSecondsList.Count == 0)

--- a/Open Judge System/Services/OJS.Services/Business/Contests/ContestsBusinessService.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/ContestsBusinessService.cs
@@ -290,7 +290,7 @@
                 responseModel.ExpectedExamSubmissions = 1;
             }
 
-            responseModel.ProcessedSubmissionsPerWorkerPerMinute = (int)Math.Round(
+            responseModel.ProcessedSubmissionsPerWorkerPerMinute = (int)Math.Ceiling(
                 60 / (1 + (model.WorkerIdleTimeInPercentage / 100.0)) / model.AverageProblemRunTimeInSeconds);
 
             var judgeParallelWorkInPercentage = model.MaxJudgeParalelWork / 100.0;

--- a/Open Judge System/Services/OJS.Services/Business/Contests/IContestsBusinessService.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/IContestsBusinessService.cs
@@ -36,6 +36,11 @@
         /// Calculates the the average runtime in seconds for specific contest
         /// </summary>
         /// <param name="contest">The contest for which the calculation will be done.</param>
-        int GetContestSubmissionsAverageRunTimeSeconds(Contest contest);
+        /// <param name="onlyOfficialSubmissions">Determines weather it takes all or only official submissions</param>
+        /// /// <param name="maxAlloweSubmissionCompletionTime">If it has value, will take only submission where completion time is lower or equal to this parameter</param>
+        int GetContestSubmissionsAverageRunTimeSeconds(
+            Contest contest,
+            bool onlyOfficialSubmissions,
+            int? maxAlloweSubmissionCompletionTime);
     }
 }

--- a/Open Judge System/Services/OJS.Services/Business/Contests/Models/BaseContestBusinessModel.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/Models/BaseContestBusinessModel.cs
@@ -4,7 +4,7 @@ namespace OJS.Services.Business.Contests.Models
 {
     public abstract class BaseContestBusinessModel
     {
-        [Range(1,1000)]
+        [Range(1, 1000)]
         public int ExamLengthInHours { get; set; }
 
         [Range(1, 100)]
@@ -14,10 +14,10 @@ namespace OJS.Services.Business.Contests.Models
         public int ExpectedStudentsCount { get; set; }
 
         [Range(1, 100000)]
-        public int PreviousContestParticipants { get; set; }
+        public int PreviousContestParticipants { get; set; } = 1;
 
         [Range(1, 10000000)]
-        public int PreviousContestSubmissions { get; set; }
+        public int PreviousContestSubmissions { get; set; } = 1;
 
         [Range(1, 1000)]
         public int AverageProblemRunTimeInSeconds { get; set; }
@@ -35,14 +35,14 @@ namespace OJS.Services.Business.Contests.Models
         public int ActualWorkers { get; set; }
 
         [Range(1, 100)]
-        public int PreviousContestExpectedProblems { get; set; }
+        public int PreviousContestExpectedProblems { get; set; } = 1;
 
         [Range(1, int.MaxValue)]
         public int CurrentContestId { get; set; }
 
         public int? PreviousContestId { get; set; }
 
-        public int PreviousAverageProblemRunTimeInSeconds { get; set; }
+        public int PreviousAverageProblemRunTimeInSeconds { get; set; } = 1;
 
     }
 }

--- a/Open Judge System/Services/OJS.Services/Business/Contests/Models/BaseContestBusinessModel.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/Models/BaseContestBusinessModel.cs
@@ -44,5 +44,7 @@ namespace OJS.Services.Business.Contests.Models
 
         public int? PreviousAverageProblemRunTimeInSeconds { get; set; }
 
+        public int MaxAllowedTimeForSubmissionCompletion { get; set; }
+
     }
 }

--- a/Open Judge System/Services/OJS.Services/Business/Contests/Models/BaseContestBusinessModel.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/Models/BaseContestBusinessModel.cs
@@ -14,10 +14,10 @@ namespace OJS.Services.Business.Contests.Models
         public int ExpectedStudentsCount { get; set; }
 
         [Range(1, 100000)]
-        public int PreviousContestParticipants { get; set; } = 1;
+        public int? PreviousContestParticipants { get; set; }
 
         [Range(1, 10000000)]
-        public int PreviousContestSubmissions { get; set; } = 1;
+        public int? PreviousContestSubmissions { get; set; }
 
         [Range(1, 1000)]
         public int AverageProblemRunTimeInSeconds { get; set; }
@@ -35,14 +35,14 @@ namespace OJS.Services.Business.Contests.Models
         public int ActualWorkers { get; set; }
 
         [Range(1, 100)]
-        public int PreviousContestExpectedProblems { get; set; } = 1;
+        public int? PreviousContestExpectedProblems { get; set; }
 
         [Range(1, int.MaxValue)]
         public int CurrentContestId { get; set; }
 
         public int? PreviousContestId { get; set; }
 
-        public int PreviousAverageProblemRunTimeInSeconds { get; set; } = 1;
+        public int? PreviousAverageProblemRunTimeInSeconds { get; set; }
 
     }
 }

--- a/Open Judge System/Services/OJS.Services/Business/Contests/Models/SubmissionRunTimeCalculationModel.cs
+++ b/Open Judge System/Services/OJS.Services/Business/Contests/Models/SubmissionRunTimeCalculationModel.cs
@@ -8,5 +8,7 @@ namespace OJS.Services.Business.Contests.Models
         public DateTime? ModifiedOn { get; set; }
 
         public DateTime? CreatedOn { get; set; }
+
+        public DateTime? CompletedExecutionOn { get; set; }
     }
 }

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.Designer.cs
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.Designer.cs
@@ -106,6 +106,15 @@ namespace Resources.Areas.Administration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Completed execution on.
+        /// </summary>
+        public static string Completed_execution_on {
+            get {
+                return ResourceManager.GetString("Completed_execution_on", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create.
         /// </summary>
         public static string Create {

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.bg.resx
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.bg.resx
@@ -132,6 +132,9 @@
   <data name="Choose_file" xml:space="preserve">
     <value>Избери файл</value>
   </data>
+  <data name="Completed_execution_on" xml:space="preserve">
+    <value>Последно завършване на изпълнение</value>
+  </data>
   <data name="Create" xml:space="preserve">
     <value>Създай</value>
   </data>

--- a/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.resx
+++ b/Open Judge System/Web/OJS.Web/App_GlobalResources/Areas/Administration/AdministrationGeneral.resx
@@ -132,6 +132,9 @@
   <data name="Choose_file" xml:space="preserve">
     <value>Choose File</value>
   </data>
+  <data name="Completed_execution_on" xml:space="preserve">
+    <value>Completed execution on</value>
+  </data>
   <data name="Create" xml:space="preserve">
     <value>Create</value>
   </data>

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/ViewModels/Submission/SubmissionAdministrationGridViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/ViewModels/Submission/SubmissionAdministrationGridViewModel.cs
@@ -34,7 +34,10 @@
                         ? SubmissionStatus.Processed
                         : SubmissionStatus.Pending,
                     CreatedOn = sub.CreatedOn,
-                    ModifiedOn = sub.ModifiedOn
+                    ModifiedOn = sub.ModifiedOn,
+                    StartedExecutionOn = sub.StartedExecutionOn,
+                    CompletedExecutionOn = sub.CompletedExecutionOn,
+                    IsOfficial = sub.Participant.IsOfficial
                 };
             }
         }
@@ -65,6 +68,12 @@
         [Display(Name = "Status", ResourceType = typeof(Resource))]
         public SubmissionStatus Status { get; set; }
 
+        public DateTime? StartedExecutionOn { get; set; }
+
+        public DateTime? CompletedExecutionOn { get; set; }
+        
+        public bool IsOfficial { get; set; }
+        
         public string ContestUrlName => this.ContestName?.ToUrl();
     }
 }

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
@@ -1,17 +1,30 @@
 ﻿@model ContestLoadCalculationViewModel
 @using OJS.Web.Areas.Administration.ViewModels.Contest
 @using OJS.Services.Business.Contests.Models
-@using System.Text;
 
 @{
     ViewBag.Title = "Calculate contest load";
     JudgeLoadResults responseModel = new JudgeLoadResults();
 }
 
+
 @section Styles {
     <link href="@Url.Content("~/Content/kendo/kendo.common.min.css")" rel="stylesheet" type="text/css"/>
     <link href="@Url.Content("~/Content/kendo/kendo.default.min.css")" rel="stylesheet" type="text/css"/>
+
 }
+
+<style>
+
+    #judge-work-results .row.k-upload-cancel,
+    #doomsday-results .row.k-upload-cancel,
+    #distribution-results .row.k-upload-cancel,
+    #previous-contest-info .row.k-upload-cancel 
+    {
+        padding: 10px;
+    }
+    
+</style>
 
 <h2>Calculate Load For Contest: @Model.ContestName </h2>
 <div id="create-form" class="online-contest-editor-container">
@@ -21,9 +34,7 @@
         <legend>Current exam info</legend>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
-                <div class="pull-right">
-                    <label>Exam length</label>
-                </div>
+                <label>Exam length</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.ExamLengthInHours, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
@@ -35,9 +46,7 @@
         </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
-                <div class="pull-right">
-                    <label>Expected exam problems</label>
-                </div>
+                <label>Expected exam problems</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.ExpectedExamProblemsCount, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
@@ -48,9 +57,7 @@
         </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
-                <div class="pull-right">
-                    <label>Expected students</label>
-                </div>
+                <label>Expected students</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.ExpectedStudentsCount, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
@@ -61,9 +68,7 @@
         </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
-                <div class="pull-right">
-                    <label>Average problem runtime in (s)</label>
-                </div>
+                <label>Average problem runtime in (s)</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.AverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
@@ -82,7 +87,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 <strong>Fill previous contest data manually</strong>
             </div>
             <div class="editor-field col-xs-2">
-                <input type="checkbox" id="toggle-previous-exams" onchange="togglePreviouseExamInputs(this)"/>
+                <input type="checkbox" id="toggle-previous-exams" onchange="togglePreviousExamInputs(this)"/>
             </div>
         </div>
 
@@ -151,7 +156,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
         </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
-                <label>Maximum Submission Completion Time(secs)</label>
+                <label>Maximum Submission Runtime(secs)</label>
             </div>
             <div class="editor-label col-xs-4 k-upload-cancel">
                 @Html.EditorFor(m => m.MaxAllowedTimeForSubmissionCompletion, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
@@ -166,9 +171,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
         <legend>Judge Settings</legend>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
-                <div class="pull-right">
-                    <label>Safety factor</label>
-                </div>
+                <label>Safety factor</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.SafetyFactor, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
@@ -179,9 +182,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
         </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
-                <div class="pull-right">
-                    <label>Work idle time in percentage</label>
-                </div>
+                <label>Work idle time in percentage</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.WorkerIdleTimeInPercentage, new { htmlAttributes = new { @class = "form-control pull-left", min = 1 } })
@@ -192,9 +193,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
         </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Max judge parallel work</label>
-                </div>
+                <label>Max judge parallel work</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.MaxJudgeParalelWork, new { htmlAttributes = new { @class = "form-control pull-left", min = 1 } })
@@ -205,9 +204,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
         </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Actual workers</label>
-                </div>
+                <label>Actual workers</label>
             </div>
             <div class="editor-field col-xs-4">
                 @Html.EditorFor(m => m.ActualWorkers, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
@@ -227,17 +224,62 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
         </div>
     </div>
 }
-<div id="previous-contests-data-results" hidden="hidden">
+<div id="previous-contests-data-results" hidden="hidden" >
     <fieldset>
+        <legend>Results</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Suggested workers</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="SuggestedWorkers" value="@responseModel.SuggestedWorkers" disabled="disabled"/>
+                 <label id="suggested-workers-helper-text" style="color:#ff0a00">Please contact dev team</label>
+            </div>
+            <div class="editor-field col-xs-3">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Suggested workers. NOTE: If you have more than 50 workers suggested here - discuss with dev team. Workers do not scale proportionally.
+                    For example, 100 workers will not have twice the performance of 50 workers.
+                    " data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <label>Time between submissions (in s)</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="SecondsBetweenSubmissionsHigh" value="@responseModel.SecondsBetweenSubmissionsHigh" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-3">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
+            on high performance scale with actual workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweak the exam itself, and not judge.
+            Suggestion is based on the safety factor below and actual workers.
+            " data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+</div>
+<div id="judge-work-wrapper" hidden class="top-buffer-lg">
+<div id="judge-work-results" class="top-buffer-lg">
+    <fieldset >
         <legend>Judge Work Results</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Expected judge work</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="TotalWork" value="@responseModel.ExpectedTotalJudgeWorkInMinutes" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Expected total judge work in minutes" data-tooltip="true"></span>
+            </div>
+        </div>
         <div class="row k-upload-cancel">
             <div class="editor-label col-xs-4 k-upload-cancel">
                 <label>Expected Submissions</label>
             </div>
             <div class="editor-field col-xs-4">
-                <input class="form-control" id="Submissions" value="@responseModel.ExpectedExamSubmissions"/>
+                <input class="form-control" id="Submissions" value="@responseModel.ExpectedExamSubmissions" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
+            <div class="editor-field col-xs-2">
                 <span class="glyphicon glyphicon-question-sign text-primary" title="Expected exam submissions" data-tooltip="true"></span>
             </div>
         </div>
@@ -246,67 +288,128 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 <label class="editor-label">Minimum workers required</label>
             </div>
             <div class="editor-field col-xs-4">
-                <input class="form-control " id="MinimumWorkersRequired" value="@responseModel.MinimumWorkersRequired"/>
+                <input class="form-control " id="MinimumWorkersRequired" value="@responseModel.MinimumWorkersRequired" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
+            <div class="editor-field col-xs-2">
                 <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required" data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <label>Suggested workers</label>
+            <div class="editor-label col-xs-4">
+                <label>Processed submissions per worker</label>
             </div>
             <div class="editor-field col-xs-4">
-                <input class="form-control" id="SuggestedWorkers" value="@responseModel.SuggestedWorkers"/>
+                <input class="form-control" id="ProcessedSubmissionsPerWorkerPerMinute" value="@responseModel.ProcessedSubmissionsPerWorkerPerMinute" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Processed submissions per worker for a minute" data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+</div>
+
+<div id="doomsday-results" class="top-buffer-lg">
+    <fieldset>
+        <legend>Doomsday Scenario Results</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <label>Judge work required</label>
             </div>
             <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Suggested workers. NOTE: If you have more than 50 workers suggested here - discuss with dev team. Workers do not scale proportionally.
-                    For example, 100 workers will not have twice the performance of 50 workers.
-                    " data-tooltip="true"></span>
+                <input class=" form-control" id="JudgeWork" value="@responseModel.JudgeWorkInMnutes" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario in minutes. NOTE: Doomsday scenario happens if all exam participants submit a solution at the same time.
+If a solution is not processed until the student can submit again, the system will be overloaded.
+Such case is highly unlikely to occur but we should design our exams with a protection in mind." data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <label>Previous contest students</label>
-            </div>
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <input class="form-control" id="PreviousContestParticipantsResult" value="@responseModel.PreviousContestParticipants"/>
+            <div class="editor-label col-xs-4">
+                <label>Judge work per worker (in min's)</label>
             </div>
             <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
+                <input class="form-control" id="JudgeWorkInMinute" value="@responseModel.JudgeWorkPerWorkerInMinutes" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario per worker in minutes. NOTE: We can introduce automation to prevent doomsday scenarios.
+For example, we can forbid the user to submit a solution for the a task, if she already has a one for it in the queue.
+" data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <label>Previous contest submissions</label>
-            </div>
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <input class="form-control" id="PreviousContestSubmissionsResult" value="@responseModel.PreviousContestSubmissions"/>
+            <div class="editor-label col-xs-4">
+                <label>Time between submissions base (in s)</label>
             </div>
             <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
+                <input class="form-control" id="SecondsBetweenSubmissionsBase" value="@responseModel.SecondsBetweenSubmissionsBase" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
+on base performance scale without additional workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweak the exam itself, and not judge.
+Suggestion is based on the safety factor below and 20 workers.
+" data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+</div>
+
+<div id="distribution-results" class="top-buffer-lg">
+    <fieldset>
+        <legend>Distribution Results</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <label>Max submissions per minute</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="MaxSubmissionsPerMinute" value="@responseModel.MaxSubmissionsPerMinute" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum submissions per minute on a distributed environment. NOTE: Calculation based on Gaussian Distribution peak - 34.1% submissions will be during 1/8 of the total exam time." data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <label>Previous contest problems</label>
-            </div>
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <input class="form-control" id="PreviousContestExpectedProblemsResult" value="@responseModel.PreviousContestExpectedProblems"/>
+            <div class="editor-label col-xs-4">
+                <label>Min workers required</label>
             </div>
             <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
+                <input class="form-control" id="MaxDistributedWorkersRequired" value="@responseModel.MaxDistributedWorkersRequired" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required for distributed maximum. NOTE: Safety factor calculated here." data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <label>Average contest problems runtime in (s)</label>
-            </div>
-            <div class="editor-label col-xs-4 k-upload-cancel">
-                <input class="form-control" id="PreviousAverageProblemRunTimeInSecondsResult" value="@responseModel.PreviousAverageProblemRunTimeInSeconds"/>
+            <div class="editor-label col-xs-4">
+                <label>Judge work required (in min's)</label>
             </div>
             <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
+                <input class="form-control" id="JudgeWorkRequiredInMinutes" value="@responseModel.JudgeWorkRequiredInMinutes" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum in minutes." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <label>Minimum workers required (in s)</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="JudgeWorkRequiredPerWorkerInSeconds" value="@responseModel.JudgeWorkRequiredPerWorkerInSeconds" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum per worker in seconds" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <label>Max users at same time</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="MaxUsersAtSameTime" value="@responseModel.MaxUsersAtSameTime" disabled="disabled"/>
+            </div>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum users at the same time on a distributed environment.NOTE: Calculation based on Gaussian Distribution peak - 34.1% ot the total users." data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
@@ -314,9 +417,9 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 <label>Time between submissions base (in s)</label>
             </div>
             <div class="editor-field col-xs-4">
-                <input class="form-control" id="SecondsBetweenSubmission" value="@responseModel.SecondsBetweenSubmission"/>
+                <input class="form-control" id="SecondsBetweenSubmission" value="@responseModel.SecondsBetweenSubmission" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
+            <div class="editor-field col-xs-2">
                 <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
             </div>
         </div>
@@ -325,222 +428,102 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 <label>Time between submissions high (in s)</label>
             </div>
             <div class="editor-field col-xs-4">
-                <input class="form-control" id="MaxSecondsBetweenSubmissions" value="@responseModel.MaxSecondsBetweenSubmissions"/>
+                <input class="form-control" id="MaxSecondsBetweenSubmissions" value="@responseModel.MaxSecondsBetweenSubmissions" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
+            <div class="editor-field col-xs-2">
                 <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum on high performance scale with actual workers. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
             </div>
         </div>
     </fieldset>
 </div>
-<div id="judge-work-wrapper" hidden class="mt-4">
+<div id="previous-contest-info" class="top-buffer-lg">
     <fieldset>
-        <legend>Judge Work Results (additional)</legend>
+        <legend>Previous contest data</legend>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Expected judge work</label>
-                </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Previous contest participants</label>
             </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="TotalWork" value="@responseModel.ExpectedTotalJudgeWorkInMinutes"/>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousContestParticipantsResult" value="@responseModel.PreviousContestParticipants" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Expected total judge work in minutes" data-tooltip="true"></span>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Processed submissions per worker</label>
-                </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Previous contest submissions</label>
             </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="ProcessedSubmissionsPerWorkerPerMinute" value="@responseModel.ProcessedSubmissionsPerWorkerPerMinute"/>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousContestSubmissionsResult" value="@responseModel.PreviousContestSubmissions" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Processed submissions per worker for a minute" data-tooltip="true"></span>
-            </div>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend>Doomsday Scenario Results</legend>
-        <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Judge work required</label>
-                </div>
-            </div>
-            <div class="editor-field col-xs-4">
-                <input class=" form-control" id="JudgeWork" value="@responseModel.JudgeWorkInMnutes"/>
-            </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario in minutes. NOTE: Doomsday scenario happens if all exam participants submit a solution at the same time.
-If a solution is not processed until the student can submit again, the system will be overloaded.
-Such case is highly unlikely to occur but we should design our exams with a protection in mind.
-Natural disasters like earthquakes are highly unlikely but each building is engineered against them.
-" data-tooltip="true"></span>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Judge work per worker (in min's)</label>
-                </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Previous contest problems</label>
             </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="JudgeWorkInMinute" value="@responseModel.JudgeWorkPerWorkerInMinutes"/>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousContestExpectedProblemsResult" value="@responseModel.PreviousContestExpectedProblems" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario per worker in minutes. NOTE: We can introduce automation to prevent doomsday scenarios.
-For example, we can forbid the user to submit a solution for the a task, if she already has a one for it in the queue.
-" data-tooltip="true"></span>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
             </div>
         </div>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Submissions on base performance (in s)</label>
-                </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Average contest problems runtime in (s)</label>
             </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="SecondsBetweenSubmissionsBase" value="@responseModel.SecondsBetweenSubmissionsBase"/>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousAverageProblemRunTimeInSecondsResult" value="@responseModel.PreviousAverageProblemRunTimeInSeconds" disabled="disabled"/>
             </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
-on base performance scale without additional workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweak the exam itself, and not judge.
-Suggestion is based on the safety factor below and 20 workers.
-" data-tooltip="true"></span>
-            </div>
-        </div>
-        <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Submissions on high performance (in s)</label>
-                </div>
-            </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="SecondsBetweenSubmissionsHigh" value="@responseModel.SecondsBetweenSubmissionsHigh"/>
-            </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
-on high performance scale with actual workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweak the exam itself, and not judge.
-Suggestion is based on the safety factor below and actual workers.
-" data-tooltip="true"></span>
-            </div>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend>Distribution Results</legend>
-        <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Max submissions per minute</label>
-                </div>
-            </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="MaxSubmissionsPerMinute" value="@responseModel.MaxSubmissionsPerMinute"/>
-            </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum submissions per minute on a distributed environment. NOTE: Calculation based on Gaussian Distribution peak - 34.1% submissions will be during 1/8 of the total exam time." data-tooltip="true"></span>
-            </div>
-        </div>
-        <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Min workers required</label>
-                </div>
-            </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="MaxDistributedWorkersRequired" value="@responseModel.MaxDistributedWorkersRequired"/>
-            </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required for distributed maximum. NOTE: Safety factor calculated here." data-tooltip="true"></span>
-            </div>
-        </div>
-        <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Judge work required (in min's)</label>
-                </div>
-            </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="JudgeWorkRequiredInMinutes" value="@responseModel.JudgeWorkRequiredInMinutes"/>
-            </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum in minutes." data-tooltip="true"></span>
-            </div>
-        </div>
-        <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Minimum workers required (in s)</label>
-                </div>
-            </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="JudgeWorkRequiredPerWorkerInSeconds" value="@responseModel.JudgeWorkRequiredPerWorkerInSeconds"/>
-            </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum per worker in seconds" data-tooltip="true"></span>
-            </div>
-        </div>
-        <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-4">
-                <div class="pull-right">
-                    <label>Max users at same time</label>
-                </div>
-            </div>
-            <div class="editor-field col-xs-4">
-                <input class="form-control" id="MaxUsersAtSameTime" value="@responseModel.MaxUsersAtSameTime"/>
-            </div>
-            <div class="editor-field col-xs-4">
-                <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum users at the same time on a distributed environment.NOTE: Calculation based on Gaussian Distribution peak - 34.1% ot the total users." data-tooltip="true"></span>
+            <div class="editor-field col-xs-2">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
             </div>
         </div>
     </fieldset>
 </div>
-
+</div>
 </div>
 
 <script>
-
+     $(document).ready(function() {
+                $("#previous-contest-info").kendoPanelBar({
+                    expandMode: "multiple",
+                    expand: onPanelBarExpand,
+                    collapse: onPanelBarCollapse
+                });
+                
+                $("#doomsday-results").kendoPanelBar({
+                    expandMode: "multiple",
+                     expand: onPanelBarExpand,
+                     collapse: onPanelBarCollapse
+                });
+                
+                $("#judge-work-results").kendoPanelBar({
+                    expandMode: "multiple",
+                     expand: onPanelBarExpand,
+                     collapse: onPanelBarCollapse
+                });   
+                
+                $("#distribution-results").kendoPanelBar({
+                    expandMode: "multiple",
+                     expand: onPanelBarExpand,
+                     collapse: onPanelBarCollapse
+                 });
+            });
     function changePreviousExam(e) {
         let receivedModel = e.sender.dataItem()
         $("#PreviousContestId").val(receivedModel.Id);
     }
 
-    function togglePreviouseExamInputs(e) {
-        let previouseContestDropdown = document.getElementById("previous-contests-wrapper");
-        let previousContestData = document.getElementById("previous-contests-data")
-
-        let previousContestParticipants =  document.getElementById("PreviousContestParticipants")
-        let previousContestSubmissions =  document.getElementById("PreviousContestSubmissions")
-        let previousContestExpectedProblems = document.getElementById("PreviousContestExpectedProblems")
-        let previousAverageProblemRunTimeInSeconds = document.getElementById("PreviousAverageProblemRunTimeInSeconds")
-
-        if (e.checked) {
-            previouseContestDropdown.style.display = "none";
-            previousContestData.style.display = "block"
-            previousContestParticipants.value = 0
-            previousContestSubmissions.value = 0
-            previousContestExpectedProblems.value = 0
-            previousAverageProblemRunTimeInSeconds.value = 0
-        }
-        else {
-            previouseContestDropdown.style.display = "block";
-            previousContestData.style.display = "none"
-            previousContestParticipants.value = null
-            previousContestSubmissions.value = null
-            previousContestExpectedProblems.value = null
-            previousAverageProblemRunTimeInSeconds.value = null
-        }
-    }
-
      $(function () {
          $('form').submit(function (event) {
-
+             let responseDataWrapper = document.getElementById('judge-work-wrapper');
+             responseDataWrapper.setAttribute("hidden","hidden");
+             
              let isPreviousExamDataManuallyAdded = document.getElementById("toggle-previous-exams").checked;
              event.preventDefault();
 
@@ -549,7 +532,7 @@ Suggestion is based on the safety factor below and actual workers.
              let params = new URLSearchParams(formData);
 
              let previousContestId = params.get("PreviousContestId");
-
+            let actualWorkers = params.get("ActualWorkers")
              if (!isPreviousExamDataManuallyAdded && !previousContestId)
              {
                  alert("Please select previous exam.")
@@ -591,7 +574,7 @@ Suggestion is based on the safety factor below and actual workers.
                      $('#PreviousContestExpectedProblemsResult').val(response.PreviousContestExpectedProblems)
                      $('#PreviousAverageProblemRunTimeInSecondsResult').val(response.PreviousAverageProblemRunTimeInSeconds)
 
-                     let responseDataWrapper = document.getElementById('judge-work-wrapper');
+                     
                      responseDataWrapper.removeAttribute("hidden");
 
                      var previousExamBox = document.getElementById("previous-contests-data")
@@ -601,11 +584,64 @@ Suggestion is based on the safety factor below and actual workers.
 
                      var previousExamBox = document.getElementById("previous-contests-data-results")
                      previousExamBox.removeAttribute("hidden");
+                     
+                     if (response.SuggestedWorkers > actualWorkers){
+                        document.getElementById("SuggestedWorkers").style.background ="rgba(255,10,0,0.4)" ;
+                        document.getElementById("suggested-workers-helper-text").removeAttribute("hidden")
+                     }
+                     else {
+                          document.getElementById("SuggestedWorkers").style.background ="rgba(5,255,36,0.4)" ;
+                          document.getElementById("suggested-workers-helper-text").setAttribute("hidden","hidden")
+                     }
                  })
                  .fail(function (error) {
                      alert(error)
                  });
         });
     });
+    function togglePreviousExamInputs(e) {
+        let previousContestDropdown = document.getElementById("previous-contests-wrapper");
+        let previousContestData = document.getElementById("previous-contests-data")
+    
+        let previousContestParticipants =  document.getElementById("PreviousContestParticipants")
+        let previousContestSubmissions =  document.getElementById("PreviousContestSubmissions")
+        let previousContestExpectedProblems = document.getElementById("PreviousContestExpectedProblems")
+        let previousAverageProblemRunTimeInSeconds = document.getElementById("PreviousAverageProblemRunTimeInSeconds")
+    
+        if (e.checked) {
+            previousContestDropdown.style.display = "none";
+            previousContestData.style.display = "block"
+            previousContestParticipants.value = 0
+            previousContestSubmissions.value = 0
+            previousContestExpectedProblems.value = 0
+            previousAverageProblemRunTimeInSeconds.value = 0
+        }
+        else {
+            previousContestDropdown.style.display = "block";
+            previousContestData.style.display = "none"
+            previousContestParticipants.value = null
+            previousContestSubmissions.value = null
+            previousContestExpectedProblems.value = null
+            previousAverageProblemRunTimeInSeconds.value = null
+        }
+    }
+    
+        function onPanelBarExpand(e) {
+            var legend = $(e.item).find("legend")[0];
+            
+            if (legend) {
+                legend.style.color = "white"; 
+            }
+        }
+        
+
+        function onPanelBarCollapse(e) {
+            var legend = $(e.item).find("legend")[0];
+            
+            if (legend) {
+                legend.style.color = ""; 
+            }
+        }
+        
 </script>
 @(Html.Kendo().Tooltip().For("#create-form").Filter("[data-tooltip='true']").Position(TooltipPosition.Bottom).Width(400))

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
@@ -7,257 +7,109 @@
     ViewBag.Title = "Calculate contest load";
     JudgeLoadResults responseModel = new JudgeLoadResults();
 }
+
 @section Styles {
-    <link href="@Url.Content("~/Content/kendo/kendo.common.min.css")" rel="stylesheet" type="text/css" />
-    <link href="@Url.Content("~/Content/kendo/kendo.default.min.css")" rel="stylesheet" type="text/css" />
+    <link href="@Url.Content("~/Content/kendo/kendo.common.min.css")" rel="stylesheet" type="text/css"/>
+    <link href="@Url.Content("~/Content/kendo/kendo.default.min.css")" rel="stylesheet" type="text/css"/>
 }
+
 <h2>Calculate Load For Contest: @Model.ContestName </h2>
 <div id="create-form" class="online-contest-editor-container">
-    @using (Html.BeginForm("CalculateContestLoad", "Contests", FormMethod.Post))
-    {
-        <fieldset>
-            <legend>Current exam info</legend>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <div class="pull-right">
-                        <label>Exam length</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.ExamLengthInHours, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                    @Html.HiddenFor(m => m.CurrentContestId)
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Exam length in hours" data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <div class="pull-right">
-                        <label>Expected exam problems</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.ExpectedExamProblemsCount, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Expected next exam number of problems. NOTE: If you have multiple exams at the same time, you need to sum their number of problems." data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <div class="pull-right">
-                        <label>Expected students</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.ExpectedStudentsCount, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Expected next exam students. NOTE: Your projection of total students or current enrollments. If you have multiple exams at the same time, you need to sum their number of students." data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <div class="pull-right">
-                        <label>Average problem runtime in (s)</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.AverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Average problem run time in seconds.NOTE: You can calculate it for each problem by the multiplying the number of tests and the problem time limit * 120% (for additional work required to process a task).
-You can also see the difference between the Modified On and the Created On properties for a solution submited on a 'calm' judge.
-Try not to design a task which takes more than 5 seconds. If you need such a problem - discuss with the dev team." data-tooltip="true"></span>
-                </div>
-            </div>
-        </fieldset>
-        <fieldset>
-            <legend>Previous exam info</legend>
-            <div class="row" style="margin-bottom:2rem">
-                <div class="editor-field col-xs-4">
-                    <strong>Fill previous contest data manually</strong>
-                </div>
-                <div class="editor-field col-xs-2">
-                    <input type="checkbox" id="toggle-previos-exams" onchange="togglePreviouseExamInputs(this)" />
-                </div>
-            </div>
-
-            <div id="previous-contests-wrapper">
-                <div class="row k-upload-cancel">
-                    <div class="col-xs-8">
-                        @(Html.Kendo().ComboBoxFor(m => m.ContestsDropdownData)
-                         .Name("dropdownlist")
-                         .DataValueField("Value")
-                         .DataTextField("Name")
-                         .BindTo((System.Collections.IEnumerable)Model.ContestsDropdownData)
-                         .HtmlAttributes(new { @class = "full-editor pull-right" })
-                         .Placeholder("Please select contest...")
-                         .Events(e => e.Change("changePreviousExam")))
-
-                        @Html.HiddenFor(m => m.PreviousContestId)
-                    </div>
-                </div>
-            </div>
-
-            <div id="previous-contests-data" style="display:none">
-                <div class="row k-upload-cancel">
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        <label>Previous contest students</label>
-                    </div>
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        @Html.EditorFor(m => m.PreviousContestParticipants, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                    </div>
-                    <div class="editor-field col-xs-4">
-                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
-                    </div>
-                </div>
-                <div class="row k-upload-cancel">
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        <label>Previous contest submissions</label>
-                    </div>
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        @Html.EditorFor(m => m.PreviousContestSubmissions, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                    </div>
-                    <div class="editor-field col-xs-4">
-                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
-                    </div>
-                </div>
-                <div class="row k-upload-cancel">
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        <label>Previous contest problems</label>
-                    </div>
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        @Html.EditorFor(m => m.PreviousContestExpectedProblems, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                    </div>
-                    <div class="editor-field col-xs-4">
-                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
-                    </div>
-                </div>
-                <div class="row k-upload-cancel">
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        <label>Average contest problems runtime in (s)</label>
-                    </div>
-                    <div class="editor-label col-xs-4 k-upload-cancel">
-                        @Html.EditorFor(m => m.PreviousAverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                    </div>
-                    <div class="editor-field col-xs-4">
-                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
-                    </div>
-                </div>
-            </div>
-        </fieldset>
-
-        <fieldset>
-            <legend>Judge Settings</legend>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <div class="pull-right">
-                        <label>Safety factor</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.SafetyFactor, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Safety factor. NOTE: We want to play it extra safe because we do not pause judge for exercises during exams so we multiply important calculations with this safety factor." data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <div class="pull-right">
-                        <label>Work idle time in percentage</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.WorkerIdleTimeInPercentage, new { htmlAttributes = new { @class = "form-control pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Worker idle time in percentage. NOTE: We do not want workers to be busy all the time. Such situation may lead to overloading, exceptions and wrong results." data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Max judge parallel work</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.MaxJudgeParalelWork, new { htmlAttributes = new { @class = "form-control pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum parallel judge work compared to exam length in percentage. NOTE: We should aim for total parallel judge work to be maximum 25% of the total exam length for safety reasons." data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Actual workers</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    @Html.EditorFor(m => m.ActualWorkers, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Number of currently running workers. NOTE: Can be taken from the LocalWorker configuration." data-tooltip="true"></span>
-                </div>
-            </div>
-        </fieldset>
-        <hr />
+@using (Html.BeginForm("CalculateContestLoad", "Contests", FormMethod.Post))
+{
+    <fieldset>
+        <legend>Current exam info</legend>
         <div class="row k-upload-cancel">
-            <div class="editor-label col-xs-6">
-                <button type="submit" class="btn btn-primary pull-right">Calculate</button>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <div class="pull-right">
+                    <label>Exam length</label>
+                </div>
             </div>
-            <div class="editor-label col-xs-6">
-                <a href="/Contests/@Model.CurrentContestId" class="btn btn-primary">Back</a>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.ExamLengthInHours, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+                @Html.HiddenFor(m => m.CurrentContestId)
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Exam length in hours" data-tooltip="true"></span>
             </div>
         </div>
-    }
-    <div id="previous-contests-data-results" hidden="hidden">
-        <fieldset>
-            <legend>Judge Work Results</legend>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Submissions</label>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="Submissions" value="@responseModel.ExpectedExamSubmissions" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Expected exam submissions" data-tooltip="true"></span>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <div class="pull-right">
+                    <label>Expected exam problems</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label class="editor-label">Minimum workers required</label>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control " id="MinimumWorkersRequired" value="@responseModel.MinimumWorkersRequired" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required" data-tooltip="true"></span>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.ExpectedExamProblemsCount, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Expected next exam number of problems. NOTE: If you have multiple exams at the same time, you need to sum their number of problems." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <div class="pull-right">
+                    <label>Expected students</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Suggested workers</label>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="SuggestedWorkers" value="@responseModel.SuggestedWorkers" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Suggested workers. NOTE: If you have more than 50 workers suggested here - discuss with dev team. Workers do not scale proportionally.
-                    For example, 100 workers will not have twice the performance of 50 workers.
-                    " data-tooltip="true"></span>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.ExpectedStudentsCount, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Expected next exam students. NOTE: Your projection of total students or current enrollments. If you have multiple exams at the same time, you need to sum their number of students." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <div class="pull-right">
+                    <label>Average problem runtime in (s)</label>
                 </div>
             </div>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.AverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Average problem run time in seconds.NOTE: You can calculate it for each problem by the multiplying the number of tests and the problem time limit * 120% (for additional work required to process a task).
+You can also see the difference between the Modified On and the Created On properties for a solution submitted on a 'calm' judge.
+Try not to design a task which takes more than 5 seconds. If you need such a problem - discuss with the dev team." data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+    <fieldset>
+        <legend>Previous exam info</legend>
+        <div class="row" style="margin-bottom:2rem">
+            <div class="editor-field col-xs-4">
+                <strong>Fill previous contest data manually</strong>
+            </div>
+            <div class="editor-field col-xs-2">
+                <input type="checkbox" id="toggle-previous-exams" onchange="togglePreviouseExamInputs(this)"/>
+            </div>
+        </div>
+
+        <div id="previous-contests-wrapper">
+            <div class="row k-upload-cancel">
+                <div class="col-xs-8">
+                    @(Html.Kendo().ComboBoxFor(m => m.ContestsDropdownData)
+                        .Name("dropdownlist")
+                        .DataValueField("Value")
+                        .DataTextField("Name")
+                        .BindTo((System.Collections.IEnumerable)Model.ContestsDropdownData)
+                        .HtmlAttributes(new { @class = "full-editor pull-right" })
+                        .Placeholder("Please select contest...")
+                        .Events(e => e.Change("changePreviousExam")))
+
+                    @Html.HiddenFor(m => m.PreviousContestId)
+                </div>
+            </div>
+        </div>
+
+        <div id="previous-contests-data" style="display:none">
             <div class="row k-upload-cancel">
                 <div class="editor-label col-xs-4 k-upload-cancel">
                     <label>Previous contest students</label>
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
-                    <input class="form-control" id="PreviousContestParticipantsResult" value="@responseModel.PreviousContestParticipants" />
+                    @Html.EditorFor(m => m.PreviousContestParticipants, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
@@ -268,7 +120,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                     <label>Previous contest submissions</label>
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
-                    <input class="form-control" id="PreviousContestSubmissionsResult" value="@responseModel.PreviousContestSubmissions" />
+                    @Html.EditorFor(m => m.PreviousContestSubmissions, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
@@ -279,7 +131,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                     <label>Previous contest problems</label>
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
-                    <input class="form-control" id="PreviousContestExpectedProblemsResult" value="@responseModel.PreviousContestExpectedProblems" />
+                    @Html.EditorFor(m => m.PreviousContestExpectedProblems, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
@@ -290,222 +142,383 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                     <label>Average contest problems runtime in (s)</label>
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
-                    <input class="form-control" id="PreviousAverageProblemRunTimeInSecondsResult" value="@responseModel.PreviousAverageProblemRunTimeInSeconds" />
+                    @Html.EditorFor(m => m.PreviousAverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Time between submissions base (in s)</label>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="SecondsBetweenSubmission" value="@responseModel.SecondsBetweenSubmission" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
-                </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Maximum Submission Completion Time(secs)</label>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Time between submissions high (in s)</label>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="MaxSecondsBetweenSubmissions" value="@responseModel.MaxSecondsBetweenSubmissions" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum on high performance scale with actual workers. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
-                </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                @Html.EditorFor(m => m.MaxAllowedTimeForSubmissionCompletion, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
             </div>
-        </fieldset>
-    </div>
-    <div id="judge-work-wrapper" hidden class="mt-4">
-        <fieldset>
-            <legend>Judge Work Results (additional)</legend>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Expected judge work</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="TotalWork" value="@responseModel.ExpectedTotalJudgeWorkInMinutes" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Expected total judge work in minutes" data-tooltip="true"></span>
-                </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Calculation of the average runtime for the previous contest will be done based on submissions, which average runtime is lower or equal to this parameter." data-tooltip="true"></span>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Processed submissions per worker</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="ProcessedSubmissionsPerWorkerPerMinute" value="@responseModel.ProcessedSubmissionsPerWorkerPerMinute" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Processed submissions per worker for a minute" data-tooltip="true"></span>
-                </div>
-            </div>
-        </fieldset>
+        </div>
+    </fieldset>
 
-        <fieldset>
-            <legend>Doomsday Scenario Results</legend>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Judge work required</label>
-                    </div>
+    <fieldset>
+        <legend>Judge Settings</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <div class="pull-right">
+                    <label>Safety factor</label>
                 </div>
-                <div class="editor-field col-xs-4">
-                    <input class=" form-control" id="JudgeWork" value="@responseModel.JudgeWorkInMnutes" />
+            </div>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.SafetyFactor, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Safety factor. NOTE: We want to play it extra safe because we do not pause judge for exercises during exams so we multiply important calculations with this safety factor." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <div class="pull-right">
+                    <label>Work idle time in percentage</label>
                 </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario in minutes. NOTE: Doomsday scenario happens if all exam participants submit a solution at the same time.
+            </div>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.WorkerIdleTimeInPercentage, new { htmlAttributes = new { @class = "form-control pull-left", min = 1 } })
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Worker idle time in percentage. NOTE: We do not want workers to be busy all the time. Such situation may lead to overloading, exceptions and wrong results." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Max judge parallel work</label>
+                </div>
+            </div>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.MaxJudgeParalelWork, new { htmlAttributes = new { @class = "form-control pull-left", min = 1 } })
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum parallel judge work compared to exam length in percentage. NOTE: We should aim for total parallel judge work to be maximum 25% of the total exam length for safety reasons." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Actual workers</label>
+                </div>
+            </div>
+            <div class="editor-field col-xs-4">
+                @Html.EditorFor(m => m.ActualWorkers, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Number of currently running workers. NOTE: Can be taken from the LocalWorker configuration." data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+    <hr/>
+    <div class="row k-upload-cancel">
+        <div class="editor-label col-xs-6">
+            <button type="submit" class="btn btn-primary pull-right">Calculate</button>
+        </div>
+        <div class="editor-label col-xs-6">
+            <a href="/Contests/@Model.CurrentContestId" class="btn btn-primary">Back</a>
+        </div>
+    </div>
+}
+<div id="previous-contests-data-results" hidden="hidden">
+    <fieldset>
+        <legend>Judge Work Results</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Expected Submissions</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="Submissions" value="@responseModel.ExpectedExamSubmissions"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Expected exam submissions" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label class="editor-label">Minimum workers required</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control " id="MinimumWorkersRequired" value="@responseModel.MinimumWorkersRequired"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Suggested workers</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="SuggestedWorkers" value="@responseModel.SuggestedWorkers"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Suggested workers. NOTE: If you have more than 50 workers suggested here - discuss with dev team. Workers do not scale proportionally.
+                    For example, 100 workers will not have twice the performance of 50 workers.
+                    " data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Previous contest students</label>
+            </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousContestParticipantsResult" value="@responseModel.PreviousContestParticipants"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Previous contest submissions</label>
+            </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousContestSubmissionsResult" value="@responseModel.PreviousContestSubmissions"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Previous contest problems</label>
+            </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousContestExpectedProblemsResult" value="@responseModel.PreviousContestExpectedProblems"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Average contest problems runtime in (s)</label>
+            </div>
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <input class="form-control" id="PreviousAverageProblemRunTimeInSecondsResult" value="@responseModel.PreviousAverageProblemRunTimeInSeconds"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Time between submissions base (in s)</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="SecondsBetweenSubmission" value="@responseModel.SecondsBetweenSubmission"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4 k-upload-cancel">
+                <label>Time between submissions high (in s)</label>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="MaxSecondsBetweenSubmissions" value="@responseModel.MaxSecondsBetweenSubmissions"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum on high performance scale with actual workers. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+</div>
+<div id="judge-work-wrapper" hidden class="mt-4">
+    <fieldset>
+        <legend>Judge Work Results (additional)</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Expected judge work</label>
+                </div>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="TotalWork" value="@responseModel.ExpectedTotalJudgeWorkInMinutes"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Expected total judge work in minutes" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Processed submissions per worker</label>
+                </div>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="ProcessedSubmissionsPerWorkerPerMinute" value="@responseModel.ProcessedSubmissionsPerWorkerPerMinute"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Processed submissions per worker for a minute" data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>Doomsday Scenario Results</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Judge work required</label>
+                </div>
+            </div>
+            <div class="editor-field col-xs-4">
+                <input class=" form-control" id="JudgeWork" value="@responseModel.JudgeWorkInMnutes"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario in minutes. NOTE: Doomsday scenario happens if all exam participants submit a solution at the same time.
 If a solution is not processed until the student can submit again, the system will be overloaded.
-Such case is highly unlikely to occur but we should desing our exams with a protection in mind.
+Such case is highly unlikely to occur but we should design our exams with a protection in mind.
 Natural disasters like earthquakes are highly unlikely but each building is engineered against them.
 " data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Judge work per worker (in min's)</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Judge work per worker (in mins)</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="JudgeWorkInMinute" value="@responseModel.JudgeWorkPerWorkerInMinutes" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario per worker in minutes. NOTE: We can introduce automation to prevent doomsday scenarios.
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="JudgeWorkInMinute" value="@responseModel.JudgeWorkPerWorkerInMinutes"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the doomsday scenario per worker in minutes. NOTE: We can introduce automation to prevent doomsday scenarios.
 For example, we can forbid the user to submit a solution for the a task, if she already has a one for it in the queue.
 " data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Submissions on base performance (in s)</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Submissions on base performance (in s)</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="SecondsBetweenSubmissionsBase" value="@responseModel.SecondsBetweenSubmissionsBase" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
-on base performance scale without additional workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweek the exam itself, and not judge.
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="SecondsBetweenSubmissionsBase" value="@responseModel.SecondsBetweenSubmissionsBase"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
+on base performance scale without additional workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweak the exam itself, and not judge.
 Suggestion is based on the safety factor below and 20 workers.
 " data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Submissions on high performance (in s)</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Submissions on high performance (in s)</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="SecondsBetweenSubmissionsHigh" value="@responseModel.SecondsBetweenSubmissionsHigh" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
-on high performance scale with actual workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweek the exam itself, and not judge.
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="SecondsBetweenSubmissionsHigh" value="@responseModel.SecondsBetweenSubmissionsHigh"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for doomsday scenario
+on high performance scale with actual workers. NOTE: Less than 30 seconds and more than 5 minutes are not desirable for various reasons. We should tweak the exam itself, and not judge.
 Suggestion is based on the safety factor below and actual workers.
 " data-tooltip="true"></span>
-                </div>
             </div>
-        </fieldset>
+        </div>
+    </fieldset>
 
-        <fieldset>
-            <legend>Distribution Results</legend>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Max submissions per minute</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="MaxSubmissionsPerMinute" value="@responseModel.MaxSubmissionsPerMinute" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum submissions per minute on a distributed environment. NOTE: Calculation based on Gaussian Distribution peak - 34.1% submissions will be during 1/8 of the total exam time." data-tooltip="true"></span>
+    <fieldset>
+        <legend>Distribution Results</legend>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Max submissions per minute</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Min workers required</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="MaxDistributedWorkersRequired" value="@responseModel.MaxDistributedWorkersRequired" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required for distributed maximum. NOTE: Safety factor calculated here." data-tooltip="true"></span>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="MaxSubmissionsPerMinute" value="@responseModel.MaxSubmissionsPerMinute"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum submissions per minute on a distributed environment. NOTE: Calculation based on Gaussian Distribution peak - 34.1% submissions will be during 1/8 of the total exam time." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Min workers required</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Judge work required (in mins)</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="JudgeWorkRequiredInMinutes" value="@responseModel.JudgeWorkRequiredInMinutes" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum in minutes." data-tooltip="true"></span>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="MaxDistributedWorkersRequired" value="@responseModel.MaxDistributedWorkersRequired"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required for distributed maximum. NOTE: Safety factor calculated here." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Judge work required (in min's)</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Minimum workers required (in s)</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="JudgeWorkRequiredPerWorkerInSeconds" value="@responseModel.JudgeWorkRequiredPerWorkerInSeconds" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum per worker in seconds" data-tooltip="true"></span>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="JudgeWorkRequiredInMinutes" value="@responseModel.JudgeWorkRequiredInMinutes"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum in minutes." data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Minimum workers required (in s)</label>
                 </div>
             </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Max users at same time</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="MaxUsersAtSameTime" value="@responseModel.MaxUsersAtSameTime" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum users at the same time on a distributed environment.NOTE: Calculation based on Gaussian Distribution peak - 34.1% ot the total users." data-tooltip="true"></span>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="JudgeWorkRequiredPerWorkerInSeconds" value="@responseModel.JudgeWorkRequiredPerWorkerInSeconds"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Judge work required for the distributed maximum per worker in seconds" data-tooltip="true"></span>
+            </div>
+        </div>
+        <div class="row k-upload-cancel">
+            <div class="editor-label col-xs-4">
+                <div class="pull-right">
+                    <label>Max users at same time</label>
                 </div>
             </div>
-        </fieldset>
-    </div>
+            <div class="editor-field col-xs-4">
+                <input class="form-control" id="MaxUsersAtSameTime" value="@responseModel.MaxUsersAtSameTime"/>
+            </div>
+            <div class="editor-field col-xs-4">
+                <span class="glyphicon glyphicon-question-sign text-primary" title="Maximum users at the same time on a distributed environment.NOTE: Calculation based on Gaussian Distribution peak - 34.1% ot the total users." data-tooltip="true"></span>
+            </div>
+        </div>
+    </fieldset>
+</div>
 
 </div>
 
 <script>
 
     function changePreviousExam(e) {
-        var receivedModel = e.sender.dataItem()
+        let receivedModel = e.sender.dataItem()
         $("#PreviousContestId").val(receivedModel.Id);
     }
 
     function togglePreviouseExamInputs(e) {
-        var previouseContestDropdown = document.getElementById("previous-contests-wrapper");
-        var previousContestData = document.getElementById("previous-contests-data")
+        let previouseContestDropdown = document.getElementById("previous-contests-wrapper");
+        let previousContestData = document.getElementById("previous-contests-data")
 
-        var previousContestParticipants =  document.getElementById("PreviousContestParticipants")
-        var previousContestSubmissions =  document.getElementById("PreviousContestSubmissions")
-        var previousContestExpectedProblems = document.getElementById("PreviousContestExpectedProblems")
-        var previousAverageProblemRunTimeInSeconds = document.getElementById("PreviousAverageProblemRunTimeInSeconds")
+        let previousContestParticipants =  document.getElementById("PreviousContestParticipants")
+        let previousContestSubmissions =  document.getElementById("PreviousContestSubmissions")
+        let previousContestExpectedProblems = document.getElementById("PreviousContestExpectedProblems")
+        let previousAverageProblemRunTimeInSeconds = document.getElementById("PreviousAverageProblemRunTimeInSeconds")
 
         if (e.checked) {
             previouseContestDropdown.style.display = "none";
@@ -528,14 +541,14 @@ Suggestion is based on the safety factor below and actual workers.
      $(function () {
          $('form').submit(function (event) {
 
-             var isPreviousExamDataManuallyAdded = document.getElementById("toggle-previos-exams").checked;
+             let isPreviousExamDataManuallyAdded = document.getElementById("toggle-previous-exams").checked;
              event.preventDefault();
 
-             var formData = $(this).serialize();
+             let formData = $(this).serialize();
 
-             var params = new URLSearchParams(formData);
+             let params = new URLSearchParams(formData);
 
-             var previousContestId = params.get("PreviousContestId");
+             let previousContestId = params.get("PreviousContestId");
 
              if (!isPreviousExamDataManuallyAdded && !previousContestId)
              {

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
@@ -258,7 +258,6 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
                     <input class="form-control" id="PreviousContestParticipantsResult" value="@responseModel.PreviousContestParticipants" />
-                    @*@Html.EditorFor(m => m.PreviousContestParticipantsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
@@ -270,7 +269,6 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
                     <input class="form-control" id="PreviousContestSubmissionsResult" value="@responseModel.PreviousContestSubmissions" />
-                    @*@Html.EditorFor(m => m.PreviousContestSubmissionsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
@@ -282,7 +280,6 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
                     <input class="form-control" id="PreviousContestExpectedProblemsResult" value="@responseModel.PreviousContestExpectedProblems" />
-                    @*@Html.EditorFor(m => m.PreviousContestExpectedProblemsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
@@ -294,7 +291,6 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 </div>
                 <div class="editor-label col-xs-4 k-upload-cancel">
                     <input class="form-control" id="PreviousAverageProblemRunTimeInSecondsResult" value="@responseModel.PreviousAverageProblemRunTimeInSeconds" />
-                    @*@Html.EditorFor(m => m.PreviousAverageProblemRunTimeInSecondsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
@@ -506,29 +502,55 @@ Suggestion is based on the safety factor below and actual workers.
         var previouseContestDropdown = document.getElementById("previous-contests-wrapper");
         var previousContestData = document.getElementById("previous-contests-data")
 
+        var previousContestParticipants =  document.getElementById("PreviousContestParticipants")
+        var previousContestSubmissions =  document.getElementById("PreviousContestSubmissions")
+        var previousContestExpectedProblems = document.getElementById("PreviousContestExpectedProblems")
+        var previousAverageProblemRunTimeInSeconds = document.getElementById("PreviousAverageProblemRunTimeInSeconds")
+
         if (e.checked) {
             previouseContestDropdown.style.display = "none";
             previousContestData.style.display = "block"
+            previousContestParticipants.value = 0
+            previousContestSubmissions.value = 0
+            previousContestExpectedProblems.value = 0
+            previousAverageProblemRunTimeInSeconds.value = 0
         }
         else {
             previouseContestDropdown.style.display = "block";
             previousContestData.style.display = "none"
+            previousContestParticipants.value = null
+            previousContestSubmissions.value = null
+            previousContestExpectedProblems.value = null
+            previousAverageProblemRunTimeInSeconds.value = null
         }
     }
 
      $(function () {
          $('form').submit(function (event) {
 
+             var isPreviousExamDataManuallyAdded = document.getElementById("toggle-previos-exams").checked;
              event.preventDefault();
 
              var formData = $(this).serialize();
+
              var params = new URLSearchParams(formData);
+
              var previousContestId = params.get("PreviousContestId");
 
-             if (!document.getElementById("toggle-previos-exams").checked && !previousContestId)
+             if (!isPreviousExamDataManuallyAdded && !previousContestId)
              {
                  alert("Please select previous exam.")
+                 return;
              }
+             if (isPreviousExamDataManuallyAdded) {
+                 params.delete("PreviousContestId")
+                 params.append("PreviousContestParticipants", document.getElementById("PreviousContestParticipants").value)
+                 params.append("PreviousContestSubmissions", document.getElementById("PreviousContestSubmissions").value)
+                 params.append("PreviousContestExpectedProblems", document.getElementById("PreviousContestExpectedProblems").value)
+                 params.append("PreviousAverageProblemRunTimeInSeconds", document.getElementById("PreviousAverageProblemRunTimeInSeconds").value)
+             }
+
+             formData = params.toString()
 
              $.post('@Url.Action("CalculateContestLoad", "Contests")', formData)
                  .done(function (response) {
@@ -568,7 +590,7 @@ Suggestion is based on the safety factor below and actual workers.
                      previousExamBox.removeAttribute("hidden");
                  })
                  .fail(function (error) {
-                     console.log(error)
+                     alert(error)
                  });
         });
     });

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Contests/CalculateContestLoad.cshtml
@@ -75,73 +75,78 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
         </fieldset>
         <fieldset>
             <legend>Previous exam info</legend>
+            <div class="row" style="margin-bottom:2rem">
+                <div class="editor-field col-xs-4">
+                    <strong>Fill previous contest data manually</strong>
+                </div>
+                <div class="editor-field col-xs-2">
+                    <input type="checkbox" id="toggle-previos-exams" onchange="togglePreviouseExamInputs(this)" />
+                </div>
+            </div>
 
-            @if (@Model.ContestsDropdownData.Any())
-            {
+            <div id="previous-contests-wrapper">
                 <div class="row k-upload-cancel">
                     <div class="col-xs-8">
-                        @(Html.Kendo().DropDownListFor(m => m.ContestsDropdownData)
+                        @(Html.Kendo().ComboBoxFor(m => m.ContestsDropdownData)
                          .Name("dropdownlist")
                          .DataValueField("Value")
                          .DataTextField("Name")
                          .BindTo((System.Collections.IEnumerable)Model.ContestsDropdownData)
                          .HtmlAttributes(new { @class = "full-editor pull-right" })
-                         .Events(e => e.Open("changePreviousExam").Change("changePreviousExam")))
+                         .Placeholder("Please select contest...")
+                         .Events(e => e.Change("changePreviousExam")))
 
                         @Html.HiddenFor(m => m.PreviousContestId)
                     </div>
                 </div>
-            }
-            else
-            {
-                <div id="previous-contests-data">
-                    <div class="row k-upload-cancel">
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            <label>Previous contest students</label>
-                        </div>
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            @Html.EditorFor(m => m.PreviousContestParticipants, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                        </div>
-                        <div class="editor-field col-xs-4">
-                            <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
-                        </div>
+            </div>
+
+            <div id="previous-contests-data" style="display:none">
+                <div class="row k-upload-cancel">
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        <label>Previous contest students</label>
                     </div>
-                    <div class="row k-upload-cancel">
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            <label>Previous contest submissions</label>
-                        </div>
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            @Html.EditorFor(m => m.PreviousContestSubmissions, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                        </div>
-                        <div class="editor-field col-xs-4">
-                            <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
-                        </div>
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        @Html.EditorFor(m => m.PreviousContestParticipants, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
                     </div>
-                    <div class="row k-upload-cancel">
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            <label>Previous contest problems</label>
-                        </div>
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            @Html.EditorFor(m => m.PreviousContestExpectedProblems, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                        </div>
-                        <div class="editor-field col-xs-4">
-                            <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
-                        </div>
-                    </div>
-                    <div class="row k-upload-cancel">
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            <label>Average contest problems runtime in (s)</label>
-                        </div>
-                        <div class="editor-label col-xs-4 k-upload-cancel">
-                            @Html.EditorFor(m => m.PreviousAverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                        </div>
-                        <div class="editor-field col-xs-4">
-                            <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
-                        </div>
+                    <div class="editor-field col-xs-4">
+                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
                     </div>
                 </div>
-            }
-
+                <div class="row k-upload-cancel">
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        <label>Previous contest submissions</label>
+                    </div>
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        @Html.EditorFor(m => m.PreviousContestSubmissions, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+                    </div>
+                    <div class="editor-field col-xs-4">
+                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
+                    </div>
+                </div>
+                <div class="row k-upload-cancel">
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        <label>Previous contest problems</label>
+                    </div>
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        @Html.EditorFor(m => m.PreviousContestExpectedProblems, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+                    </div>
+                    <div class="editor-field col-xs-4">
+                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
+                    </div>
+                </div>
+                <div class="row k-upload-cancel">
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        <label>Average contest problems runtime in (s)</label>
+                    </div>
+                    <div class="editor-label col-xs-4 k-upload-cancel">
+                        @Html.EditorFor(m => m.PreviousAverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
+                    </div>
+                    <div class="editor-field col-xs-4">
+                        <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
+                    </div>
+                </div>
+            </div>
         </fieldset>
 
         <fieldset>
@@ -195,7 +200,7 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                     @Html.EditorFor(m => m.ActualWorkers, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
                 </div>
                 <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Actual workers" data-tooltip="true"></span>
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Number of currently running workers. NOTE: Can be taken from the LocalWorker configuration." data-tooltip="true"></span>
                 </div>
             </div>
         </fieldset>
@@ -209,15 +214,12 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
             </div>
         </div>
     }
-
-    <div id="judge-work-wrapper" hidden>
+    <div id="previous-contests-data-results" hidden="hidden">
         <fieldset>
             <legend>Judge Work Results</legend>
             <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Submissions</label>
-                    </div>
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Submissions</label>
                 </div>
                 <div class="editor-field col-xs-4">
                     <input class="form-control" id="Submissions" value="@responseModel.ExpectedExamSubmissions" />
@@ -226,6 +228,105 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Expected exam submissions" data-tooltip="true"></span>
                 </div>
             </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label class="editor-label">Minimum workers required</label>
+                </div>
+                <div class="editor-field col-xs-4">
+                    <input class="form-control " id="MinimumWorkersRequired" value="@responseModel.MinimumWorkersRequired" />
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required" data-tooltip="true"></span>
+                </div>
+            </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Suggested workers</label>
+                </div>
+                <div class="editor-field col-xs-4">
+                    <input class="form-control" id="SuggestedWorkers" value="@responseModel.SuggestedWorkers" />
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Suggested workers. NOTE: If you have more than 50 workers suggested here - discuss with dev team. Workers do not scale proportionally.
+                    For example, 100 workers will not have twice the performance of 50 workers.
+                    " data-tooltip="true"></span>
+                </div>
+            </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Previous contest students</label>
+                </div>
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <input class="form-control" id="PreviousContestParticipantsResult" value="@responseModel.PreviousContestParticipants" />
+                    @*@Html.EditorFor(m => m.PreviousContestParticipantsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
+                </div>
+            </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Previous contest submissions</label>
+                </div>
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <input class="form-control" id="PreviousContestSubmissionsResult" value="@responseModel.PreviousContestSubmissions" />
+                    @*@Html.EditorFor(m => m.PreviousContestSubmissionsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
+                </div>
+            </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Previous contest problems</label>
+                </div>
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <input class="form-control" id="PreviousContestExpectedProblemsResult" value="@responseModel.PreviousContestExpectedProblems" />
+                    @*@Html.EditorFor(m => m.PreviousContestExpectedProblemsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
+                </div>
+            </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Average contest problems runtime in (s)</label>
+                </div>
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <input class="form-control" id="PreviousAverageProblemRunTimeInSecondsResult" value="@responseModel.PreviousAverageProblemRunTimeInSeconds" />
+                    @*@Html.EditorFor(m => m.PreviousAverageProblemRunTimeInSecondsResult, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })*@
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
+                </div>
+            </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Time between submissions base (in s)</label>
+                </div>
+                <div class="editor-field col-xs-4">
+                    <input class="form-control" id="SecondsBetweenSubmission" value="@responseModel.SecondsBetweenSubmission" />
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
+                </div>
+            </div>
+            <div class="row k-upload-cancel">
+                <div class="editor-label col-xs-4 k-upload-cancel">
+                    <label>Time between submissions high (in s)</label>
+                </div>
+                <div class="editor-field col-xs-4">
+                    <input class="form-control" id="MaxSecondsBetweenSubmissions" value="@responseModel.MaxSecondsBetweenSubmissions" />
+                </div>
+                <div class="editor-field col-xs-4">
+                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum on high performance scale with actual workers. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
+                </div>
+            </div>
+        </fieldset>
+    </div>
+    <div id="judge-work-wrapper" hidden class="mt-4">
+        <fieldset>
+            <legend>Judge Work Results (additional)</legend>
             <div class="row k-upload-cancel">
                 <div class="editor-label col-xs-4">
                     <div class="pull-right">
@@ -250,34 +351,6 @@ Try not to design a task which takes more than 5 seconds. If you need such a pro
                 </div>
                 <div class="editor-field col-xs-4">
                     <span class="glyphicon glyphicon-question-sign text-primary" title="Processed submissions per worker for a minute" data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label class="editor-label">Minimum workers required</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control " id="MinimumWorkersRequired" value="@responseModel.MinimumWorkersRequired" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Minimum workers required" data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Suggested workers</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="SuggestedWorkers" value="@responseModel.SuggestedWorkers" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Suggested workers. NOTE: If you have more than 50 workers suggested here - discuss with dev team. Workers do not scale proportionally.
-                    For example, 100 workers will not have twice the performance of 50 workers.
-                    " data-tooltip="true"></span>
                 </div>
             </div>
         </fieldset>
@@ -407,32 +480,6 @@ Suggestion is based on the safety factor below and actual workers.
             <div class="row k-upload-cancel">
                 <div class="editor-label col-xs-4">
                     <div class="pull-right">
-                        <label>Seconds between submissions base</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="SecondsBetweenSubmission" value="@responseModel.SecondsBetweenSubmission" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
-                        <label>Seconds between submissions high</label>
-                    </div>
-                </div>
-                <div class="editor-field col-xs-4">
-                    <input class="form-control" id="MaxSecondsBetweenSubmissions" value="@responseModel.MaxSecondsBetweenSubmissions" />
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Seconds between submissions for the distributed maximum on high performance scale with actual workers. NOTE: Safety factor calculated here. " data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4">
-                    <div class="pull-right">
                         <label>Max users at same time</label>
                     </div>
                 </div>
@@ -445,55 +492,7 @@ Suggestion is based on the safety factor below and actual workers.
             </div>
         </fieldset>
     </div>
-    <div id="previous-contests-data-results" hidden="hidden">
-        <fieldset>
-            <legend>Previous exam data</legend>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Previous contest students</label>
-                </div>
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    @Html.EditorFor(m => m.PreviousContestParticipants, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam students" data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Previous contest submissions</label>
-                </div>
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    @Html.EditorFor(m => m.PreviousContestSubmissions, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam total submissions" data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Previous contest problems</label>
-                </div>
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    @Html.EditorFor(m => m.PreviousContestExpectedProblems, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of problems" data-tooltip="true"></span>
-                </div>
-            </div>
-            <div class="row k-upload-cancel">
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    <label>Average contest problems runtime in (s)</label>
-                </div>
-                <div class="editor-label col-xs-4 k-upload-cancel">
-                    @Html.EditorFor(m => m.PreviousAverageProblemRunTimeInSeconds, new { htmlAttributes = new { @class = "form-control full-editor pull-left", min = 1 } })
-                </div>
-                <div class="editor-field col-xs-4">
-                    <span class="glyphicon glyphicon-question-sign text-primary" title="Previous exam number of average problem run time in seconds" data-tooltip="true"></span>
-                </div>
-            </div>
-        </fieldset>
-    </div>
+
 </div>
 
 <script>
@@ -503,11 +502,33 @@ Suggestion is based on the safety factor below and actual workers.
         $("#PreviousContestId").val(receivedModel.Id);
     }
 
+    function togglePreviouseExamInputs(e) {
+        var previouseContestDropdown = document.getElementById("previous-contests-wrapper");
+        var previousContestData = document.getElementById("previous-contests-data")
+
+        if (e.checked) {
+            previouseContestDropdown.style.display = "none";
+            previousContestData.style.display = "block"
+        }
+        else {
+            previouseContestDropdown.style.display = "block";
+            previousContestData.style.display = "none"
+        }
+    }
+
      $(function () {
          $('form').submit(function (event) {
 
-            event.preventDefault();
+             event.preventDefault();
+
              var formData = $(this).serialize();
+             var params = new URLSearchParams(formData);
+             var previousContestId = params.get("PreviousContestId");
+
+             if (!document.getElementById("toggle-previos-exams").checked && !previousContestId)
+             {
+                 alert("Please select previous exam.")
+             }
 
              $.post('@Url.Action("CalculateContestLoad", "Contests")', formData)
                  .done(function (response) {
@@ -530,10 +551,10 @@ Suggestion is based on the safety factor below and actual workers.
                      $('#MaxSecondsBetweenSubmissions').val(response.MaxSecondsBetweenSubmissions);
                      $('#MaxUsersAtSameTime').val(response.MaxUsersAtSameTime.toFixed(3));
 
-                     $('#PreviousContestParticipants').val(response.PreviousContestParticipants)
-                     $('#PreviousContestSubmissions').val(response.PreviousContestSubmissions)
-                     $('#PreviousContestExpectedProblems').val(response.PreviousContestExpectedProblems)
-                     $('#PreviousAverageProblemRunTimeInSeconds').val(response.PreviousAverageProblemRunTimeInSeconds)
+                     $('#PreviousContestParticipantsResult').val(response.PreviousContestParticipants)
+                     $('#PreviousContestSubmissionsResult').val(response.PreviousContestSubmissions)
+                     $('#PreviousContestExpectedProblemsResult').val(response.PreviousContestExpectedProblems)
+                     $('#PreviousAverageProblemRunTimeInSecondsResult').val(response.PreviousAverageProblemRunTimeInSeconds)
 
                      let responseDataWrapper = document.getElementById('judge-work-wrapper');
                      responseDataWrapper.removeAttribute("hidden");

--- a/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Submissions/_SubmissionsGrid.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Administration/Views/Submissions/_SubmissionsGrid.cshtml
@@ -23,6 +23,9 @@
         columns.Bound(model => model.Points);
         columns.Bound(model => model.CreatedOn).Filterable(x => x.UI(GridFilterUIRole.DateTimePicker)).Hidden();
         columns.Bound(model => model.ModifiedOn).Filterable(x => x.UI(GridFilterUIRole.DateTimePicker)).Hidden();
+        columns.Bound(model => model.StartedExecutionOn).Filterable(x => x.UI(GridFilterUIRole.DateTimePicker)).Hidden();
+        columns.Bound(model => model.CompletedExecutionOn).Filterable(x => x.UI(GridFilterUIRole.DateTimePicker)).Hidden();
+        columns.Bound(model => model.IsOfficial).Filterable(x => x.UI(GridFilterUIRole.Default)).Hidden();
         columns.Template(@<text></text>).ClientTemplate("<a href='" + Url.Action("Update", ControllerName) + "/#= Id #' class='k-button k-button-icontext'>" + GeneralResource.Change + "</a>").Title(GeneralResource.Change);
         columns.Template(@<text></text>).ClientTemplate("<a href='" + Url.Action("Delete", ControllerName) + "/#= Id #' class='k-button k-button-icontext'>" + GeneralResource.Delete + "</a>").Title(GeneralResource.Delete);
         columns.Template(@<text></text>).ClientTemplate("<a href='" + Url.Action("View", "Submissions", new { Area = "Contests" }) + "/#= Id #' class='k-button k-button-icontext' target='_blank'>" + Resource.Details + "</a>").Title(Resource.Details);

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Controllers/ResultsController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Controllers/ResultsController.cs
@@ -458,7 +458,16 @@
 
             return this.PartialView("_StatsChartPartial", contestId);
         }
-
+        
+        private static void SetContestResults(ContestResultsViewModel contestResults, IOrderedEnumerable<ParticipantResultViewModel> participantResults)
+        {
+            contestResults.Results = participantResults
+                .ThenBy(parResult => parResult.ProblemResults
+                    .OrderByDescending(pr => pr.BestSubmission.Id)
+                    .Select(pr => pr.BestSubmission.Id)
+                    .FirstOrDefault());
+        }
+        
         private ContestResultsViewModel GetContestResults(
             Contest contest,
             bool official,
@@ -599,15 +608,6 @@
                 outputStream.ToArray(), // The binary data of the XLS file
                 GlobalConstants.ExcelMimeType, // MIME type of Excel files
                 fileName);
-        }
-
-        private static void SetContestResults(ContestResultsViewModel contestResults, IOrderedEnumerable<ParticipantResultViewModel> participantResults)
-        {
-            contestResults.Results = participantResults
-                            .ThenBy(parResult => parResult.ProblemResults
-                                .OrderByDescending(pr => pr.BestSubmission.Id)
-                                .Select(pr => pr.BestSubmission.Id)
-                                .FirstOrDefault());
         }
     }
 }

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Submissions/SubmissionDetailsViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Submissions/SubmissionDetailsViewModel.cs
@@ -37,7 +37,8 @@
                 TestRuns = submission.TestRuns.AsQueryable().Select(TestRunDetailsViewModel.FromTestRun),
                 ExecutionComment = submission.ExecutionComment,
                 ExceptionType = submission.ExceptionType,
-                StartedExecutionOn = submission.StartedExecutionOn
+                StartedExecutionOn = submission.StartedExecutionOn,
+                CompletedExecutionOn = submission.CompletedExecutionOn,
             };
 
         public int Id { get; set; }
@@ -102,5 +103,6 @@
 
         public DateTime? StartedExecutionOn { get; set; }
 
+        public DateTime? CompletedExecutionOn { get; set; }
     }
 }

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Contests/Details.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Contests/Details.cshtml
@@ -218,11 +218,11 @@
                     new { area = GlobalConstants.AdministrationAreaName },
                     new { @class = "btn btn-sm btn-primary bottom-buffer-sm" }))
             }
-            if (Model.UserIsAdminOrLecturerInContest && Model.StartTime.HasValue && Model.EndTime.HasValue)
+            if (Model.UserIsAdminOrLecturerInContest)
             {
                 @(Html.ActionLink<ContestsController>(
                     Resource.Calculate_load,
-                    c => c.CalculateContestLoad(Model.CategoryId.Value,Model.Id),
+                    c => c.CalculateContestLoad(Model.Id),
                     new { area = GlobalConstants.AdministrationAreaName },
                     new { @class = "btn btn-sm btn-primary bottom-buffer-sm left-buffer" }))
             }

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
@@ -358,6 +358,7 @@ else
 {
     <p>@AdministrationResource.Modified_on: @Model.ModifiedOn</p>
     <p>@AdministrationResource.Started_execution_on: @Model.StartedExecutionOn</p>
+    <p>@AdministrationResource.Completed_execution_on: @Model.CompletedExecutionOn</p>
 }
 
 <script>

--- a/Open Judge System/Web/OJS.Web/Controllers/BaseController.cs
+++ b/Open Judge System/Web/OJS.Web/Controllers/BaseController.cs
@@ -10,9 +10,7 @@
     using System.Web.Mvc.Expressions;
     using System.Web.Routing;
     using System.Web.Script.Serialization;
-
     using MvcThrottle;
-
     using OJS.Common;
     using OJS.Data;
     using OJS.Data.Models;
@@ -20,7 +18,6 @@
     using OJS.Services.Data.Contests;
     using OJS.Web.Common;
     using OJS.Web.Common.Extensions;
-
     using static OJS.Common.GlobalConstants;
 
     // TODO: handle setting ViewBag data throught the help of this attribute
@@ -37,7 +34,8 @@
 
         protected UserProfile UserProfile { get; set; }
 
-        protected internal RedirectToRouteResult RedirectToAction<TController>(Expression<Action<TController>> expression)
+        protected internal RedirectToRouteResult RedirectToAction<TController>(
+            Expression<Action<TController>> expression)
             where TController : Controller
         {
             if (expression.Body is MethodCallExpression method)
@@ -98,7 +96,8 @@
             {
                 var controllerName = this.ControllerContext.RouteData.Values["Controller"].ToString();
                 var actionName = this.ControllerContext.RouteData.Values["Action"].ToString();
-                this.View("Error", new HandleErrorInfo(filterContext.Exception, controllerName, actionName)).ExecuteResult(this.ControllerContext);
+                this.View("Error", new HandleErrorInfo(filterContext.Exception, controllerName, actionName))
+                    .ExecuteResult(this.ControllerContext);
             }
 
             filterContext.ExceptionHandled = true;
@@ -125,52 +124,34 @@
             var contestsData = ObjectFactory.GetInstance<IContestsDataService>();
 
             return this.UserProfile != null &&
-                (this.User.IsAdmin() ||
+                   (this.User.IsAdmin() ||
                     contestsData.IsUserLecturerInByContestAndUser(contestId, this.UserProfile.Id));
         }
 
         protected bool CheckIfUserHasProblemPermissions(int problemId) =>
             this.UserProfile != null &&
             (this.User.IsAdmin() ||
-                this.Data.Problems
-                    .All()
-                    .Any(x =>
-                        x.Id == problemId &&
-                        (x.ProblemGroup.Contest.Lecturers.Any(y => y.LecturerId == this.UserProfile.Id) ||
-                        x.ProblemGroup.Contest.Category.Lecturers.Any(cl => cl.LecturerId == this.UserProfile.Id))));
+             this.Data.Problems
+                 .All()
+                 .Any(x =>
+                     x.Id == problemId &&
+                     (x.ProblemGroup.Contest.Lecturers.Any(y => y.LecturerId == this.UserProfile.Id) ||
+                      x.ProblemGroup.Contest.Category.Lecturers.Any(cl => cl.LecturerId == this.UserProfile.Id))));
 
         protected bool CheckIfUserHasContestCategoryPermissions(int categoryId) =>
             this.UserProfile != null &&
             (this.User.IsAdmin() ||
-                this.Data.ContestCategories
-                    .All()
-                    .Any(x =>
-                        x.Id == categoryId &&
-                        x.Lecturers.Any(y => y.LecturerId == this.UserProfile.Id)));
+             this.Data.ContestCategories
+                 .All()
+                 .Any(x =>
+                     x.Id == categoryId &&
+                     x.Lecturers.Any(y => y.LecturerId == this.UserProfile.Id)));
 
         protected bool CheckIfUserOwnsSubmission(int submissionId) =>
             this.UserProfile != null &&
             this.Data.Submissions
                 .All()
                 .Any(s => s.Id == submissionId && s.Participant.UserId == this.UserProfile.Id);
-
-        private static void SetUiCultureFromCookie(RequestContext requestContext)
-        {
-            var languageCookie = requestContext.HttpContext.Request.Cookies[GlobalConstants.LanguageCookieName];
-
-            if (languageCookie == null)
-            {
-                languageCookie = new HttpCookie(GlobalConstants.LanguageCookieName, GlobalConstants.EnglishCultureCookieValue);
-                requestContext.HttpContext.Response.AppendCookie(languageCookie);
-            }
-
-            switch (languageCookie.Value)
-            {
-                default:
-                    Thread.CurrentThread.CurrentUICulture = new CultureInfo(GlobalConstants.EnglishCultureInfoName);
-                    break;
-            }
-        }
 
         protected SystemMessageCollection PrepareSystemMessages()
         {
@@ -196,6 +177,26 @@
             }
 
             return messages;
+        }
+
+        private static void SetUiCultureFromCookie(RequestContext requestContext)
+        {
+            var languageCookie = requestContext.HttpContext.Request.Cookies[GlobalConstants.LanguageCookieName];
+
+            if (languageCookie == null)
+            {
+                languageCookie = new HttpCookie(
+                    GlobalConstants.LanguageCookieName,
+                    GlobalConstants.EnglishCultureCookieValue);
+                requestContext.HttpContext.Response.AppendCookie(languageCookie);
+            }
+
+            switch (languageCookie.Value)
+            {
+                default:
+                    Thread.CurrentThread.CurrentUICulture = new CultureInfo(GlobalConstants.EnglishCultureInfoName);
+                    break;
+            }
         }
     }
 }

--- a/Open Judge System/Web/OJS.Web/Infrastructure/Filters/ValidateRemoteDataApiKeyFilter.cs
+++ b/Open Judge System/Web/OJS.Web/Infrastructure/Filters/ValidateRemoteDataApiKeyFilter.cs
@@ -23,7 +23,6 @@
         public ValidateRemoteDataApiKeyFilter(IOjsDbContext context) => 
             this.userManager = new OjsUserManager<UserProfile>(new UserStore<UserProfile>(context.DbContext));
 
-
         public void OnActionExecuting(
             ValidateRemoteDataApiKeyAttribute attribute,
             ActionExecutingContext filterContext)

--- a/Open Judge System/Web/OJS.Web/ViewModels/Search/SearchResultViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/ViewModels/Search/SearchResultViewModel.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace OJS.Web.ViewModels.Search
+﻿namespace OJS.Web.ViewModels.Search
 {
     using System;
     using System.Linq.Expressions;


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/824
           https://github.com/SoftUni-Internal/exam-systems-issues/issues/816

Related pull request https://github.com/SoftUni-Internal/judge-worker/pull/143
https://github.com/SoftUni-Internal/interactive/pull/1588

Implemented property "CompletedExecutionOn" when the execution result is saved in Submissions table;
Fixes applied to the Contest Load page:
1. Seconds between submissions base/high renamed to Time between submissions base/high(in s)
2. Getting problems fixed to take proper count of problems.
3. Default value for expected students is changed to be 0 since it we are not getting it from SULS.
4. The previous exam dropdown is changed to be ComboBox and now it loads all contests no matter in which category.
5. Added checkbox to allow Admin to add previous contest data manually in case it is needed.
6. The Actual Workers now will be get from setting in the database
7. The important values in the results will be shown first in the results.