### PR TITLE
Fixing active remaining time for contests

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
@@ -52,7 +52,6 @@ interface IContestType {
     resultsArePubliclyVisible: boolean;
     hasContestPassword: boolean;
     hasPracticePassword: boolean;
-    remainingTimeInMilliseconds: number;
     userIsAdminOrLecturerInContest: boolean;
     userCanCompete: boolean;
     userIsParticipant: false;
@@ -107,7 +106,7 @@ interface IStartParticipationResponseType {
     participantId: number;
     contestIsCompete: boolean;
     lastSubmissionTime: Date;
-    remainingTimeInMilliseconds: number;
+    endDateTimeForParticipantOrContest: Date | null;
     userSubmissionsTimeLimit: number;
     totalParticipantsCount: number;
     activeParticipantsCount: number;

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-problem-details/ContestProblemDetails.module.scss
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-problem-details/ContestProblemDetails.module.scss
@@ -11,7 +11,7 @@
 }
 
 .centeredFlex {
+  align-items: center;
   display: flex;
   justify-content: center;
-  align-items: center;
 }

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest/Contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest/Contest.tsx
@@ -6,9 +6,9 @@ import { useCurrentContest } from '../../../hooks/use-current-contest';
 import { usePageTitles } from '../../../hooks/use-page-titles';
 import { useProblems } from '../../../hooks/use-problems';
 import concatClassNames from '../../../utils/class-names';
-import { convertToTwoDigitValues } from '../../../utils/dates';
+import { convertToSecondsRemaining, getLocalDateTimeInUTC } from '../../../utils/dates';
 import { flexCenterObjectStyles } from '../../../utils/object-utils';
-import Countdown, { ICountdownRemainingType, Metric } from '../../guidelines/countdown/Countdown';
+import Countdown, { Metric } from '../../guidelines/countdown/Countdown';
 import Heading, { HeadingType } from '../../guidelines/headings/Heading';
 import SpinningLoader from '../../guidelines/spinning-loader/SpinningLoader';
 import Text, { TextType } from '../../guidelines/text/Text';
@@ -24,7 +24,7 @@ const Contest = () => {
             contest,
             score,
             maxScore,
-            remainingTimeInMilliseconds,
+            endDateTimeForParticipantOrContest,
             totalParticipantsCount,
             activeParticipantsCount,
             isOfficial,
@@ -80,28 +80,6 @@ const Contest = () => {
         [ scoreText ],
     );
 
-    const remainingTimeClassName = 'remainingTime';
-    const renderCountdown = useCallback(
-        (remainingTime: ICountdownRemainingType) => {
-            const { hours, minutes, seconds } = convertToTwoDigitValues(remainingTime);
-
-            return (
-                <p className={remainingTimeClassName}>
-                    Remaining time:
-                    {' '}
-                    <Text type={TextType.Bold}>
-                        {hours}
-                        :
-                        {minutes}
-                        :
-                        {seconds}
-                    </Text>
-                </p>
-            );
-        },
-        [],
-    );
-
     const handleCountdownEnd = useCallback(
         () => {
             setIsSubmitAllowed(canAccessAdministration || false);
@@ -111,22 +89,19 @@ const Contest = () => {
 
     const renderTimeRemaining = useCallback(
         () => {
-            if (!remainingTimeInMilliseconds) {
+            if (isNil(endDateTimeForParticipantOrContest) || new Date(endDateTimeForParticipantOrContest) < getLocalDateTimeInUTC()) {
                 return null;
             }
 
-            const currentSeconds = remainingTimeInMilliseconds / 1000;
-
             return (
                 <Countdown
-                  renderRemainingTime={renderCountdown}
-                  duration={currentSeconds}
+                  duration={convertToSecondsRemaining(new Date(endDateTimeForParticipantOrContest))}
                   metric={Metric.seconds}
                   handleOnCountdownEnd={handleCountdownEnd}
                 />
             );
         },
-        [ handleCountdownEnd, remainingTimeInMilliseconds, renderCountdown ],
+        [ endDateTimeForParticipantOrContest, handleCountdownEnd ],
     );
 
     const secondaryHeadingClassName = useMemo(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/countdown/Countdown.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/countdown/Countdown.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { convertToTwoDigitValues, secondsToFullTime } from '../../../utils/dates';
+import Text, { TextType } from '../text/Text';
 
 enum Metric {
     seconds = 1,
@@ -24,20 +25,63 @@ interface ICountdownProps {
     handleOnCountdownChange?: (seconds: number) => void;
 }
 
+const remainingTimeClassName = 'remainingTime';
+
+const renderTimeOut = () => (
+    <p className={remainingTimeClassName}>
+        Remaining time:
+        {' '}
+        <Text type={TextType.Bold}>
+            {' '}
+            00:00:00
+        </Text>
+    </p>
+);
+
 const defaultRender = (remainingTime: ICountdownRemainingType) => {
-    const { hours, minutes, seconds } = convertToTwoDigitValues(remainingTime);
+    const { days, hours, minutes, seconds } = convertToTwoDigitValues(remainingTime);
+
+    if (!Number(days)) {
+        return (
+            <p className={remainingTimeClassName}>
+                Remaining time:
+                {' '}
+                <Text type={TextType.Bold}>
+                    {' '}
+                    {hours}
+                    {' '}
+                    hours,
+                    {' '}
+                    {minutes}
+                    {' '}
+                    minutes,
+                    {' '}
+                    {seconds}
+                    {' '}
+                    seconds
+                </Text>
+            </p>
+        );
+    }
 
     return (
-        <p>
+        <p className={remainingTimeClassName}>
             Remaining time:
             {' '}
-            <span>
+            <Text type={TextType.Bold}>
+                {' '}
+                {days}
+                {' '}
+                days,
+                {' '}
                 {hours}
-                :
+                {' '}
+                hours,
+                {' '}
                 {minutes}
-                :
-                {seconds}
-            </span>
+                {' '}
+                minutes
+            </Text>
         </p>
     );
 };
@@ -70,8 +114,6 @@ const Countdown = ({
     useEffect(() => {
         if (remainingInSeconds < 0) {
             handleOnCountdownEnd();
-
-            return () => null;
         }
 
         const timer = setTimeout(decreaseRemainingTime, 1000);
@@ -83,11 +125,9 @@ const Countdown = ({
         handleOnCountdownChange(remainingInSeconds);
     }, [ handleOnCountdownChange, remainingInSeconds ]);
 
-    return (
-        <>
-            {renderRemainingTime(secondsToFullTime(remainingInSeconds))}
-        </>
-    );
+    return remainingInSeconds <= 0
+        ? renderTimeOut()
+        : renderRemainingTime(secondsToFullTime(remainingInSeconds));
 };
 
 export default Countdown;

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/spinning-loader/SpinningLoader.scss
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/spinning-loader/SpinningLoader.scss
@@ -1,21 +1,21 @@
 ﻿.lds-ring {
   display: inline-block;
+  height: 80px;
   position: relative;
   width: 80px;
-  height: 80px;
 }
 
 .lds-ring div {
+  animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  border: 8px solid #fff;
+  border-color: #42abf8 transparent transparent;
+  border-radius: 50%;
   box-sizing: border-box;
   display: block;
-  position: absolute;
-  width: 64px;
   height: 64px;
   margin: 8px;
-  border: 8px solid #fff;
-  border-radius: 50%;
-  animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
-  border-color: #42abf8 transparent transparent;
+  position: absolute;
+  width: 64px;
 }
 
 .lds-ring div:nth-child(1) {
@@ -34,7 +34,7 @@
   0% {
     transform: rotate(0deg);
   }
-  
+
   100% {
     transform: rotate(360deg);
   }

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/home-contests/contest-card/ContestCard.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/home-contests/contest-card/ContestCard.tsx
@@ -7,7 +7,7 @@ import { IIndexContestsType } from '../../../common/types';
 import { useAppUrls } from '../../../hooks/use-app-urls';
 import { useModal } from '../../../hooks/use-modal';
 import concatClassNames from '../../../utils/class-names';
-import { convertToSecondsRemaining } from '../../../utils/dates';
+import { convertToSecondsRemaining, getLocalDateTimeInUTC } from '../../../utils/dates';
 import { Button, ButtonSize, ButtonState, LinkButton, LinkButtonType } from '../../guidelines/buttons/Button';
 import Countdown, { Metric } from '../../guidelines/countdown/Countdown';
 import LockIcon from '../../guidelines/icons/LockIcon';
@@ -46,15 +46,13 @@ const ContestCard = ({ contest }: IContestCardProps) => {
 
     const renderCountdown = useCallback(
         () => {
-            const endDate = canBeCompeted
+            const endDate = endTime !== null
                 ? endTime
-                : practiceEndTime;
+                : practiceEndTime !== null
+                    ? practiceEndTime
+                    : null;
 
-            if (canBePracticed && isNil(practiceEndTime) && isNil(endDate)) {
-                return <p>No practice end time.</p>;
-            }
-
-            if ((!canBePracticed && !canBeCompeted) || isNil(endDate)) {
+            if (isNil(endDate) || new Date(endDate) < getLocalDateTimeInUTC()) {
                 return null;
             }
 
@@ -66,7 +64,7 @@ const ContestCard = ({ contest }: IContestCardProps) => {
                 />
             );
         },
-        [ canBeCompeted, canBePracticed, endTime, id, practiceEndTime ],
+        [ endTime, id, practiceEndTime ],
     );
 
     const renderContestLockIcon = useCallback(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
@@ -46,7 +46,7 @@ interface ICurrentContestContext {
         requirePassword: boolean | null;
         contestPasswordError: IErrorDataType | null;
         isPasswordValid: boolean | null;
-        remainingTimeInMilliseconds: number;
+        endDateTimeForParticipantOrContest: Date | null;
         userSubmissionsTimeLimit: number;
         totalParticipantsCount: number;
         activeParticipantsCount: number;
@@ -78,7 +78,6 @@ const defaultState = {
         maxScore: 0,
         isOfficial: false,
         isPasswordValid: false,
-        remainingTimeInMilliseconds: 0.0,
         userSubmissionsTimeLimit: 0,
         totalParticipantsCount: 0,
         activeParticipantsCount: 0,
@@ -124,7 +123,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
     const [ contestPasswordError, setContestPasswordError ] = useState<IErrorDataType | null>(null);
     const [ isPasswordValid, setIsPasswordValid ] = useState<boolean>(defaultState.state.isPasswordValid);
     const [ userSubmissionsTimeLimit, setUserSubmissionsTimeLimit ] = useState<number>(0);
-    const [ remainingTimeInMilliseconds, setRemainingTimeInMilliseconds ] = useState(defaultState.state.remainingTimeInMilliseconds);
+    const [ endDateTimeForParticipantOrContest, setEndDateTimeForParticipantOrContest ] = useState<Date | null>(null);
     const [ totalParticipantsCount, setTotalParticipantsCount ] = useState(defaultState.state.totalParticipantsCount);
     const [ activeParticipantsCount, setActiveParticipantsCount ] = useState(defaultState.state.activeParticipantsCount);
     const [ isSubmitAllowed, setIsSubmitAllowed ] = useState<boolean>(true);
@@ -338,7 +337,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 contest: newContest,
                 contestIsCompete,
                 participantId: currentParticipantId,
-                remainingTimeInMilliseconds: newRemainingTimeInMilliseconds,
+                endDateTimeForParticipantOrContest: newEndDateTimeForParticipantOrContest,
                 totalParticipantsCount: newTotalParticipants,
                 activeParticipantsCount: newActiveParticipants,
             } = startContestData;
@@ -346,7 +345,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
             setContest(newContest);
             setIsOfficial(contestIsCompete);
             setParticipantId(currentParticipantId);
-            setRemainingTimeInMilliseconds(newRemainingTimeInMilliseconds);
+            setEndDateTimeForParticipantOrContest(newEndDateTimeForParticipantOrContest);
             setUserSubmissionsTimeLimit(startContestData.userSubmissionsTimeLimit);
             setTotalParticipantsCount(newTotalParticipants);
             setActiveParticipantsCount(newActiveParticipants);
@@ -395,7 +394,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 requirePassword,
                 contestPasswordError,
                 isPasswordValid,
-                remainingTimeInMilliseconds,
+                endDateTimeForParticipantOrContest,
                 userSubmissionsTimeLimit,
                 totalParticipantsCount,
                 activeParticipantsCount,
@@ -426,7 +425,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
             isPasswordValid,
             maxScore,
             registerParticipant,
-            remainingTimeInMilliseconds,
+            endDateTimeForParticipantOrContest,
             userSubmissionsTimeLimit,
             requirePassword,
             score,

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -1,4 +1,4 @@
-import { intervalToDuration } from 'date-fns';
+import { differenceInDays, intervalToDuration } from 'date-fns';
 import moment from 'moment';
 
 const defaultDateTimeFormat = 'HH:MM, DD/MMM/yyyy';
@@ -21,25 +21,36 @@ const formatDate = (
     ? preciseFormatDate(date, formatString)
     : moment(date).utc(true).local().fromNow());
 
+const getLocalDateTimeInUTC = () => {
+    const now = new Date();
+    return new Date(now.getTime() + now.getTimezoneOffset() * 60000);
+};
 const convertToSecondsRemaining = (date: Date) => {
-    const { days, hours, minutes, seconds } = intervalToDuration({
-        start: new Date(),
+    const currentDate = getLocalDateTimeInUTC();
+    const { hours, minutes, seconds } = intervalToDuration({
+        start: currentDate,
         end: date,
     });
 
-    const daysRemaining = days ?? 0;
+    const daysRemaining = differenceInDays(date, currentDate);
 
     const hoursRemaining = daysRemaining * 24 + (hours ?? 0);
+
     const minutesRemaining = hoursRemaining * 60 + (minutes ?? 0);
 
     return minutesRemaining * 60 + (seconds ?? 0);
 };
 
+// This function converts a given duration in seconds into a time object that includes
+// days, hours, minutes, and seconds.
+// The function first calculates the number of whole days within the duration
+// The remaining seconds are computed using the modulus operator (%)
+// The function 'intervalToDuration' is then used to break down the remaining seconds into h, m, s
 const secondsToFullTime = (duration: number) => {
-    const { days: daysInitial, hours: hoursInitial, minutes: minutesInitial, seconds: secondsInitial } =
-        intervalToDuration({ start: 0, end: duration * 1000 });
-
-    const days = daysInitial ?? 0;
+    const days = Math.floor(duration / 86400); // Number of seconds in a day: 86400 (60 seconds * 60 minutes * 24 hours)
+    const remainingSeconds = duration % 86400;
+    const { hours: hoursInitial, minutes: minutesInitial, seconds: secondsInitial } =
+        intervalToDuration({ start: 0, end: remainingSeconds * 1000 });
 
     const hours = hoursInitial ?? 0;
 
@@ -51,16 +62,21 @@ const secondsToFullTime = (duration: number) => {
 };
 
 interface IConvertToTwoDigitValuesParamType {
+    days: number;
     hours: number;
     minutes: number;
     seconds: number;
 }
 
 const convertToTwoDigitValues = ({
+    days: daysValue,
     hours: hoursValue,
     minutes: minutesValue,
     seconds: secondsValue,
 }: IConvertToTwoDigitValuesParamType) => {
+    const days = daysValue >= 10
+        ? daysValue.toString()
+        : `0${daysValue}`;
     const hours = hoursValue >= 10
         ? hoursValue.toString()
         : `0${hoursValue}`;
@@ -74,6 +90,7 @@ const convertToTwoDigitValues = ({
         : `0${secondsValue}`;
 
     return {
+        days,
         hours,
         minutes,
         seconds,
@@ -87,6 +104,7 @@ export default {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
+    getLocalDateTimeInUTC,
 };
 
 export {
@@ -96,4 +114,5 @@ export {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
+    getLocalDateTimeInUTC,
 };

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
@@ -18,7 +18,7 @@ public class ContestParticipationServiceModel : IMapExplicitly
 
     public int? UserSubmissionsTimeLimit { get; set; }
 
-    public double? RemainingTimeInMilliseconds { get; set; }
+    public DateTime? EndDateTimeForParticipantOrContest { get; set; }
 
     public bool ShouldEnterPassword { get; set; }
 
@@ -33,10 +33,14 @@ public class ContestParticipationServiceModel : IMapExplicitly
                 s.Submissions.Any()
                     ? (DateTime?)s.Submissions.Max(x => x.CreatedOn)
                     : null))
-            .ForMember(d => d.RemainingTimeInMilliseconds, opt => opt.MapFrom(s =>
+            .ForMember(d => d.EndDateTimeForParticipantOrContest, opt => opt.MapFrom(s =>
                 s.ParticipationEndTime.HasValue
-                    ? (s.ParticipationEndTime.Value - DateTime.UtcNow).TotalMilliseconds
-                    : 0))
+                    ? s.ParticipationEndTime
+                    : (s.Contest.EndTime.HasValue
+                        ? s.Contest.EndTime
+                        : (s.Contest.PracticeEndTime.HasValue
+                            ? s.Contest.PracticeEndTime
+                            : null))))
             .ForMember(d => d.TotalParticipantsCount, opt => opt.MapFrom(s =>
                 s.Contest.Participants.Count))
             .ForMember(d => d.ActiveParticipantsCount, opt => opt.MapFrom(s =>

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestServiceModel.cs
@@ -15,7 +15,7 @@ public class ContestServiceModel : IMapExplicitly
 
     public string Name { get; set; } = null!;
 
-    public int Type { get; set; }
+    public ContestType Type { get; set; }
 
     public int? CategoryId { get; set; }
 
@@ -54,8 +54,6 @@ public class ContestServiceModel : IMapExplicitly
     public int PracticeParticipants { get; set; }
 
     public int ProblemsCount { get; set; }
-
-    public ContestType ContestType { get; set; }
 
     public IEnumerable<SubmissionTypeServiceModel> AllowedSubmissionTypes { get; set; } = null!;
 
@@ -152,19 +150,6 @@ public class ContestServiceModel : IMapExplicitly
 
     public bool HasPracticePassword => this.PracticePassword != null;
 
-    public double? RemainingTimeInMilliseconds
-    {
-        get
-        {
-            if (this.EndTime.HasValue)
-            {
-                return (this.EndTime.Value - DateTime.Now).TotalMilliseconds;
-            }
-
-            return null;
-        }
-    }
-
     public bool UserIsAdminOrLecturerInContest { get; set; }
 
     public bool UserCanCompete { get; set; }
@@ -190,7 +175,7 @@ public class ContestServiceModel : IMapExplicitly
             .ForMember(
                 d => d.ProblemsCount,
                 opt => opt.MapFrom(s => s.ProblemGroups.SelectMany(pg => pg.Problems).Count(p => !p.IsDeleted)))
-            .ForMember(d => d.ContestType, opt => opt.MapFrom(s => s.Type))
+            .ForMember(d => d.Type, opt => opt.MapFrom(s => s.Type))
             .ForMember(
                 d => d.AllowedSubmissionTypes,
                 opt =>


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/746

**Summary of the changes made**:
1. Removing unused property from ContestServiceModel and renaming ConteType property's name to match the db model
2. Removing remainingTimeInMilliseconds property from ContestParticipationServiceModel and replacing it with a DateTime EndDateTimeForParticipantOrContest with the needed changes in the RegisterMappings
3. ContestCard's renderCountDown now sets endTime to contest.endTime or contest.practiceEndtime or null. Added check for null or date in the past.
4. Removing some logic from Contest and reusing available renderCountDown logic from Countdown. Contest.tsx passes the Date variable endDateTimeForParticipantOrContest to Countdown and all calculations are not deligated to dates.ts and Countdown.
5. Changes to default render to display days, hours, minutes if days are available, if not hours, minutes, seconds. Adding logic from Contest to Countdown. Adding renderTimeOut function to display 0 values for when countdown has ended.
6. Adding a function to convert the local Data variable to UTC time. Adding daysRemaning variable in convertToSecondsRemaining. Changing the logic in secondToFulltime (comment included). Adding days variable to convertToTwoDigitValues
7. Adding endDateTimeForParticipantOrContest to ICurrentContestContext and IStartParticipationResponseType

Calculation flow and logic diagrams available in PR's issue
