### PR TITLE
Cache active and total participants on contest page

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
@@ -109,8 +109,7 @@ interface IStartParticipationResponseType {
     lastSubmissionTime: Date;
     remainingTimeInMilliseconds: number;
     userSubmissionsTimeLimit: number;
-    practiceParticipantsCount: number;
-    competeParticipantsCount: number;
+    participantsCount: number;
 }
 
 interface IPagedResultType<TItem> {

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
@@ -109,8 +109,8 @@ interface IStartParticipationResponseType {
     lastSubmissionTime: Date;
     remainingTimeInMilliseconds: number;
     userSubmissionsTimeLimit: number;
-    totalParticipantsCount: number;
-    activeParticipantsCount: number;
+    practiceParticipantsCount: number;
+    competeParticipantsCount: number;
 }
 
 interface IPagedResultType<TItem> {

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest/Contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest/Contest.tsx
@@ -25,8 +25,8 @@ const Contest = () => {
             score,
             maxScore,
             remainingTimeInMilliseconds,
-            totalParticipantsCount,
-            activeParticipantsCount,
+            competeParticipantsCount,
+            practiceParticipantsCount,
             isOfficial,
             contestError,
             contestIsLoading,
@@ -144,33 +144,24 @@ const Contest = () => {
         [],
     );
 
-    const participantsStateText = useMemo(
-        () => isOfficial && contest?.isExam
-            ? 'Active'
-            : 'Total',
-        [ contest?.isExam, isOfficial ],
-    );
-
     const participantsValue = useMemo(
         () => isOfficial && contest?.isExam
-            ? activeParticipantsCount
-            : totalParticipantsCount,
-        [ activeParticipantsCount, contest?.isExam, isOfficial, totalParticipantsCount ],
+            ? competeParticipantsCount
+            : practiceParticipantsCount,
+        [ practiceParticipantsCount, contest?.isExam, isOfficial, competeParticipantsCount ],
     );
 
     const renderParticipants = useCallback(
         () => (
             <span>
-                {participantsStateText}
-                {' '}
-                Participants:
+                Total Participants:
                 {' '}
                 <Text type={TextType.Bold}>
                     {participantsValue}
                 </Text>
             </span>
         ),
-        [ participantsStateText, participantsValue ],
+        [ participantsValue ],
     );
 
     useEffect(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest/Contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest/Contest.tsx
@@ -25,9 +25,7 @@ const Contest = () => {
             score,
             maxScore,
             remainingTimeInMilliseconds,
-            competeParticipantsCount,
-            practiceParticipantsCount,
-            isOfficial,
+            participantsCount,
             contestError,
             contestIsLoading,
         },
@@ -144,24 +142,17 @@ const Contest = () => {
         [],
     );
 
-    const participantsValue = useMemo(
-        () => isOfficial && contest?.isExam
-            ? competeParticipantsCount
-            : practiceParticipantsCount,
-        [ practiceParticipantsCount, contest?.isExam, isOfficial, competeParticipantsCount ],
-    );
-
     const renderParticipants = useCallback(
         () => (
             <span>
                 Total Participants:
                 {' '}
                 <Text type={TextType.Bold}>
-                    {participantsValue}
+                    {participantsCount}
                 </Text>
             </span>
         ),
-        [ participantsValue ],
+        [ participantsCount ],
     );
 
     useEffect(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
@@ -48,8 +48,7 @@ interface ICurrentContestContext {
         isPasswordValid: boolean | null;
         remainingTimeInMilliseconds: number;
         userSubmissionsTimeLimit: number;
-        practiceParticipantsCount: number;
-        competeParticipantsCount: number;
+        participantsCount: number;
         isSubmitAllowed: boolean;
         contestError: IErrorDataType | null;
         isRegisterForContestSuccessful: boolean;
@@ -81,8 +80,7 @@ const defaultState = {
         isPasswordValid: false,
         remainingTimeInMilliseconds: 0.0,
         userSubmissionsTimeLimit: 0,
-        practiceParticipantsCount: 0,
-        competeParticipantsCount: 0,
+        participantsCount: 0,
         isUserParticipant: false,
     },
 };
@@ -126,8 +124,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
     const [ isPasswordValid, setIsPasswordValid ] = useState<boolean>(defaultState.state.isPasswordValid);
     const [ userSubmissionsTimeLimit, setUserSubmissionsTimeLimit ] = useState<number>(0);
     const [ remainingTimeInMilliseconds, setRemainingTimeInMilliseconds ] = useState(defaultState.state.remainingTimeInMilliseconds);
-    const [ practiceParticipantsCount, setPracticeParticipantsCount ] = useState(defaultState.state.practiceParticipantsCount);
-    const [ competeParticipantsCount, setCompeteParticipantsCount ] = useState(defaultState.state.competeParticipantsCount);
+    const [ participantsCount, setParticipantsCount ] = useState(defaultState.state.participantsCount);
     const [ isSubmitAllowed, setIsSubmitAllowed ] = useState<boolean>(true);
     const [ contestError, setContestError ] = useState<IErrorDataType | null>(null);
     const [ isUserParticipant, setIsUserParticipant ] = useState<boolean>(defaultState.state.isUserParticipant);
@@ -347,8 +344,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 contestIsCompete,
                 participantId: currentParticipantId,
                 remainingTimeInMilliseconds: newRemainingTimeInMilliseconds,
-                practiceParticipantsCount: newPracticeParticipants,
-                competeParticipantsCount: newCompeteParticipants,
+                participantsCount: newParticipantsCount,
             } = startContestData;
 
             setContest(newContest);
@@ -356,8 +352,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
             setParticipantId(currentParticipantId);
             setRemainingTimeInMilliseconds(newRemainingTimeInMilliseconds);
             setUserSubmissionsTimeLimit(startContestData.userSubmissionsTimeLimit);
-            setPracticeParticipantsCount(newPracticeParticipants);
-            setCompeteParticipantsCount(newCompeteParticipants);
+            setParticipantsCount(newParticipantsCount);
 
             setRequirePassword(null);
             setIsPasswordValid(defaultState.state.isPasswordValid);
@@ -405,8 +400,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 isPasswordValid,
                 remainingTimeInMilliseconds,
                 userSubmissionsTimeLimit,
-                practiceParticipantsCount,
-                competeParticipantsCount,
+                participantsCount,
                 isSubmitAllowed,
                 contestError,
                 isRegisterForContestSuccessful,
@@ -443,8 +437,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
             contestPasswordError,
             submitPassword,
             loadParticipantScores,
-            practiceParticipantsCount,
-            competeParticipantsCount,
+            participantsCount,
             isSubmitAllowed,
             setIsSubmitAllowed,
             contestError,

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
@@ -48,8 +48,8 @@ interface ICurrentContestContext {
         isPasswordValid: boolean | null;
         remainingTimeInMilliseconds: number;
         userSubmissionsTimeLimit: number;
-        totalParticipantsCount: number;
-        activeParticipantsCount: number;
+        practiceParticipantsCount: number;
+        competeParticipantsCount: number;
         isSubmitAllowed: boolean;
         contestError: IErrorDataType | null;
         isRegisterForContestSuccessful: boolean;
@@ -81,8 +81,8 @@ const defaultState = {
         isPasswordValid: false,
         remainingTimeInMilliseconds: 0.0,
         userSubmissionsTimeLimit: 0,
-        totalParticipantsCount: 0,
-        activeParticipantsCount: 0,
+        practiceParticipantsCount: 0,
+        competeParticipantsCount: 0,
         isUserParticipant: false,
     },
 };
@@ -126,8 +126,8 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
     const [ isPasswordValid, setIsPasswordValid ] = useState<boolean>(defaultState.state.isPasswordValid);
     const [ userSubmissionsTimeLimit, setUserSubmissionsTimeLimit ] = useState<number>(0);
     const [ remainingTimeInMilliseconds, setRemainingTimeInMilliseconds ] = useState(defaultState.state.remainingTimeInMilliseconds);
-    const [ totalParticipantsCount, setTotalParticipantsCount ] = useState(defaultState.state.totalParticipantsCount);
-    const [ activeParticipantsCount, setActiveParticipantsCount ] = useState(defaultState.state.activeParticipantsCount);
+    const [ practiceParticipantsCount, setPracticeParticipantsCount ] = useState(defaultState.state.practiceParticipantsCount);
+    const [ competeParticipantsCount, setCompeteParticipantsCount ] = useState(defaultState.state.competeParticipantsCount);
     const [ isSubmitAllowed, setIsSubmitAllowed ] = useState<boolean>(true);
     const [ contestError, setContestError ] = useState<IErrorDataType | null>(null);
     const [ isUserParticipant, setIsUserParticipant ] = useState<boolean>(defaultState.state.isUserParticipant);
@@ -347,8 +347,8 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 contestIsCompete,
                 participantId: currentParticipantId,
                 remainingTimeInMilliseconds: newRemainingTimeInMilliseconds,
-                totalParticipantsCount: newTotalParticipants,
-                activeParticipantsCount: newActiveParticipants,
+                practiceParticipantsCount: newPracticeParticipants,
+                competeParticipantsCount: newCompeteParticipants,
             } = startContestData;
 
             setContest(newContest);
@@ -356,8 +356,8 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
             setParticipantId(currentParticipantId);
             setRemainingTimeInMilliseconds(newRemainingTimeInMilliseconds);
             setUserSubmissionsTimeLimit(startContestData.userSubmissionsTimeLimit);
-            setTotalParticipantsCount(newTotalParticipants);
-            setActiveParticipantsCount(newActiveParticipants);
+            setPracticeParticipantsCount(newPracticeParticipants);
+            setCompeteParticipantsCount(newCompeteParticipants);
 
             setRequirePassword(null);
             setIsPasswordValid(defaultState.state.isPasswordValid);
@@ -405,8 +405,8 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 isPasswordValid,
                 remainingTimeInMilliseconds,
                 userSubmissionsTimeLimit,
-                totalParticipantsCount,
-                activeParticipantsCount,
+                practiceParticipantsCount,
+                competeParticipantsCount,
                 isSubmitAllowed,
                 contestError,
                 isRegisterForContestSuccessful,
@@ -443,8 +443,8 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
             contestPasswordError,
             submitPassword,
             loadParticipantScores,
-            totalParticipantsCount,
-            activeParticipantsCount,
+            practiceParticipantsCount,
+            competeParticipantsCount,
             isSubmitAllowed,
             setIsSubmitAllowed,
             contestError,

--- a/Services/Common/OJS.Services.Common.Models/Cache/ContestParticipantsViewModel.cs
+++ b/Services/Common/OJS.Services.Common.Models/Cache/ContestParticipantsViewModel.cs
@@ -1,8 +1,0 @@
-﻿namespace OJS.Services.Common.Models.Cache;
-
-public class ContestParticipantsViewModel
-{
-    public int CompeteParticipantsCount { get; set; }
-
-    public int PracticeParticipantsCount { get; set; }
-}

--- a/Services/Common/OJS.Services.Common.Models/Cache/ContestParticipantsViewModel.cs
+++ b/Services/Common/OJS.Services.Common.Models/Cache/ContestParticipantsViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace OJS.Services.Common.Models.Cache;
+
+public class ContestParticipantsViewModel
+{
+    public int CompeteParticipantsCount { get; set; }
+
+    public int PracticeParticipantsCount { get; set; }
+}

--- a/Services/Infrastructure/OJS.Services.Infrastructure/Constants/CacheConstants.cs
+++ b/Services/Infrastructure/OJS.Services.Infrastructure/Constants/CacheConstants.cs
@@ -5,9 +5,11 @@
         public const int OneHourInSeconds = 60 * 60;
         public const int OneDayInSeconds = 86400;
         public const int TwoMinutesInSeconds = 120;
+        public const int FiveMinutesInSeconds = 300;
 
         public const string MainContestCategoriesDropDown = "MainContestCategoriesDropDown";
         public const string ContestResults = "Contest_id_{0}official{1}full{2}";
+        public const string ContestParticipants = "Contest_id_{0}";
         public const string ContestCategoriesTree = "ContestCategoriesTree";
         public const string ContestSubCategoriesFormat = "ContestSubCategories_id_{0}";
         public const string ContestParentCategoriesFormat = "ContestParentCategories_id_{0}";

--- a/Services/Infrastructure/OJS.Services.Infrastructure/Constants/CacheConstants.cs
+++ b/Services/Infrastructure/OJS.Services.Infrastructure/Constants/CacheConstants.cs
@@ -9,7 +9,8 @@
 
         public const string MainContestCategoriesDropDown = "MainContestCategoriesDropDown";
         public const string ContestResults = "Contest_id_{0}official{1}full{2}";
-        public const string ContestParticipants = "Contest_id_{0}";
+        public const string PracticeContestParticipantsCount = "ContestPartcipantsCount:Practice:{0}";
+        public const string CompeteContestParticipantsCount = "ContestPartcipantsCount:Compete:{0}";
         public const string ContestCategoriesTree = "ContestCategoriesTree";
         public const string ContestSubCategoriesFormat = "ContestSubCategories_id_{0}";
         public const string ContestParentCategoriesFormat = "ContestParentCategories_id_{0}";

--- a/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 public interface IContestParticipantsCacheService : IService
 {
-    Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+    Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds);
 
-    Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+    Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds);
 }

--- a/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
@@ -2,12 +2,11 @@
 
 using SoftUni.Services.Infrastructure;
 using OJS.Services.Infrastructure.Constants;
-using OJS.Services.Common.Models.Cache;
 using System.Threading.Tasks;
 
 public interface IContestParticipantsCacheService : IService
 {
-    Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+    Task<int> GetCompeteContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds);
 
-    Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+    Task<int> GetPracticeContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds);
 }

--- a/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
@@ -2,10 +2,12 @@
 
 using SoftUni.Services.Infrastructure;
 using OJS.Services.Infrastructure.Constants;
+using OJS.Services.Common.Models.Cache;
+using System.Threading.Tasks;
 
 public interface IContestParticipantsCacheService : IService
 {
-    int GetParticipantsCountByContestAndIsOfficial(int contestId, bool official, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+    Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
 
-    int GetParticipantsCountByContest(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+    Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
 }

--- a/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/IContestParticipantsCacheService.cs
@@ -1,0 +1,11 @@
+﻿namespace OJS.Services.Ui.Business.Cache;
+
+using SoftUni.Services.Infrastructure;
+using OJS.Services.Infrastructure.Constants;
+
+public interface IContestParticipantsCacheService : IService
+{
+    int GetParticipantsCountByContestAndIsOfficial(int contestId, bool official, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+
+    int GetParticipantsCountByContest(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds);
+}

--- a/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
@@ -16,14 +16,14 @@ public class ContestParticipantsCacheService : IContestParticipantsCacheService
         this.participantsBusinessService = participantsBusinessService;
     }
 
-    public Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds)
-        => this.cache.Get(
+    public async Task<int> GetCompeteContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+        => await this.cache.Get(
             string.Format(CacheConstants.CompeteContestParticipantsCount, contestId),
             () => this.participantsBusinessService.GetCompeteParticipantsCount(contestId),
             cacheSeconds);
 
-    public Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds)
-        => this.cache.Get(
+    public async Task<int> GetPracticeContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+        => await this.cache.Get(
             string.Format(CacheConstants.PracticeContestParticipantsCount, contestId),
             () => this.participantsBusinessService.GetPracticeParticipantsCount(contestId),
             cacheSeconds);

--- a/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
@@ -16,23 +16,15 @@ public class ContestParticipantsCacheService : IContestParticipantsCacheService
         this.participantsBusinessService = participantsBusinessService;
     }
 
-    public Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
-        => cacheSeconds.HasValue
-            ? this.cache.Get(
-                string.Format(CacheConstants.CompeteContestParticipantsCount, contestId),
-                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId),
-                cacheSeconds.Value)
-            : this.cache.Get(
-                string.Format(CacheConstants.CompeteContestParticipantsCount, contestId),
-                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId));
+    public Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+        => this.cache.Get(
+            string.Format(CacheConstants.CompeteContestParticipantsCount, contestId),
+            () => this.participantsBusinessService.GetCompeteParticipantsCount(contestId),
+            cacheSeconds);
 
-    public Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
-        => cacheSeconds.HasValue
-            ? this.cache.Get(
-                string.Format(CacheConstants.PracticeContestParticipantsCount, contestId),
-                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId),
-                cacheSeconds.Value)
-            : this.cache.Get(
-                string.Format(CacheConstants.PracticeContestParticipantsCount, contestId),
-                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId));
+    public Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+        => this.cache.Get(
+            string.Format(CacheConstants.PracticeContestParticipantsCount, contestId),
+            () => this.participantsBusinessService.GetPracticeParticipantsCount(contestId),
+            cacheSeconds);
 }

--- a/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
@@ -1,0 +1,38 @@
+﻿namespace OJS.Services.Ui.Business.Cache.Implementations;
+
+using OJS.Services.Infrastructure.Constants;
+using System.Linq;
+using OJS.Services.Infrastructure.Cache;
+using Data;
+
+public class ContestParticipantsCacheService : IContestParticipantsCacheService
+{
+    private readonly ICacheService cache;
+    private readonly IParticipantsDataService participantsDataService;
+
+    public ContestParticipantsCacheService(ICacheService cache, IParticipantsDataService participantsDataService)
+    {
+        this.cache = cache;
+        this.participantsDataService = participantsDataService;
+    }
+
+    public int GetParticipantsCountByContestAndIsOfficial(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+        => cacheSeconds.HasValue
+            ? this.cache.Get(
+                string.Format(CacheConstants.ContestParticipants, contestId),
+                () => this.participantsDataService.GetAllOfficialByContest(contestId),
+                cacheSeconds.Value).Count()
+            : this.cache.Get(
+                string.Format(CacheConstants.ContestParticipants, contestId),
+                () => this.participantsDataService.GetAllOfficialByContest(contestId)).Count();
+
+    public int GetParticipantsCountByContest(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+        => cacheSeconds.HasValue
+            ? this.cache.Get(
+                string.Format(CacheConstants.ContestParticipants, contestId),
+                () => this.participantsDataService.GetAllByContest(contestId),
+                cacheSeconds.Value).Count()
+            : this.cache.Get(
+                string.Format(CacheConstants.ContestParticipants, contestId),
+                () => this.participantsDataService.GetAllByContest(contestId).Count());
+}

--- a/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Cache/Implementations/ContestParticipantsCacheService.cs
@@ -1,38 +1,38 @@
 ﻿namespace OJS.Services.Ui.Business.Cache.Implementations;
 
 using OJS.Services.Infrastructure.Constants;
-using System.Linq;
 using OJS.Services.Infrastructure.Cache;
-using Data;
+using OJS.Services.Common.Models.Cache;
+using System.Threading.Tasks;
 
 public class ContestParticipantsCacheService : IContestParticipantsCacheService
 {
     private readonly ICacheService cache;
-    private readonly IParticipantsDataService participantsDataService;
+    private readonly IParticipantsBusinessService participantsBusinessService;
 
-    public ContestParticipantsCacheService(ICacheService cache, IParticipantsDataService participantsDataService)
+    public ContestParticipantsCacheService(ICacheService cache, IParticipantsBusinessService participantsBusinessService)
     {
         this.cache = cache;
-        this.participantsDataService = participantsDataService;
+        this.participantsBusinessService = participantsBusinessService;
     }
 
-    public int GetParticipantsCountByContestAndIsOfficial(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+    public Task<ContestParticipantsViewModel> GetCompeteContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
         => cacheSeconds.HasValue
             ? this.cache.Get(
-                string.Format(CacheConstants.ContestParticipants, contestId),
-                () => this.participantsDataService.GetAllOfficialByContest(contestId),
-                cacheSeconds.Value).Count()
+                string.Format(CacheConstants.CompeteContestParticipantsCount, contestId),
+                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId),
+                cacheSeconds.Value)
             : this.cache.Get(
-                string.Format(CacheConstants.ContestParticipants, contestId),
-                () => this.participantsDataService.GetAllOfficialByContest(contestId)).Count();
+                string.Format(CacheConstants.CompeteContestParticipantsCount, contestId),
+                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId));
 
-    public int GetParticipantsCountByContest(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
+    public Task<ContestParticipantsViewModel> GetPracticeContestParticipantsCount(int contestId, int? cacheSeconds = CacheConstants.FiveMinutesInSeconds)
         => cacheSeconds.HasValue
             ? this.cache.Get(
-                string.Format(CacheConstants.ContestParticipants, contestId),
-                () => this.participantsDataService.GetAllByContest(contestId),
-                cacheSeconds.Value).Count()
+                string.Format(CacheConstants.PracticeContestParticipantsCount, contestId),
+                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId),
+                cacheSeconds.Value)
             : this.cache.Get(
-                string.Format(CacheConstants.ContestParticipants, contestId),
-                () => this.participantsDataService.GetAllByContest(contestId).Count());
+                string.Format(CacheConstants.PracticeContestParticipantsCount, contestId),
+                () => this.participantsBusinessService.GetParticipantsCountByContest(contestId));
 }

--- a/Services/UI/OJS.Services.Ui.Business/IParticipantsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/IParticipantsBusinessService.cs
@@ -37,8 +37,8 @@ namespace OJS.Services.Ui.Business
 
         Task<int> GetParticipantLimitBetweenSubmissions(int participantId, int contestLimitBetweenSubmissions);
 
-        Task<ContestParticipantsViewModel> GetPracticeParticipantsCount(int contestId);
+        Task<int> GetPracticeParticipantsCount(int contestId);
 
-        Task<ContestParticipantsViewModel> GetCompeteParticipantsCount(int contestId);
+        Task<int> GetCompeteParticipantsCount(int contestId);
     }
 }

--- a/Services/UI/OJS.Services.Ui.Business/IParticipantsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/IParticipantsBusinessService.cs
@@ -1,12 +1,13 @@
 namespace OJS.Services.Ui.Business
 {
-    using OJS.Data.Models.Contests;
-    using OJS.Data.Models.Participants;
-    using OJS.Services.Common.Models;
-    using SoftUni.Services.Infrastructure;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using OJS.Data.Models.Contests;
+    using OJS.Data.Models.Participants;
+    using OJS.Services.Common.Models;
+    using OJS.Services.Common.Models.Cache;
+    using SoftUni.Services.Infrastructure;
 
     public interface IParticipantsBusinessService : IService
     {
@@ -35,5 +36,7 @@ namespace OJS.Services.Ui.Business
             DateTime participationStartTimeRangeEnd);
 
         Task<int> GetParticipantLimitBetweenSubmissions(int participantId, int contestLimitBetweenSubmissions);
+
+        Task<ContestParticipantsViewModel> GetParticipantsCountByContest(int contestId);
     }
 }

--- a/Services/UI/OJS.Services.Ui.Business/IParticipantsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/IParticipantsBusinessService.cs
@@ -37,6 +37,8 @@ namespace OJS.Services.Ui.Business
 
         Task<int> GetParticipantLimitBetweenSubmissions(int participantId, int contestLimitBetweenSubmissions);
 
-        Task<ContestParticipantsViewModel> GetParticipantsCountByContest(int contestId);
+        Task<ContestParticipantsViewModel> GetPracticeParticipantsCount(int contestId);
+
+        Task<ContestParticipantsViewModel> GetCompeteParticipantsCount(int contestId);
     }
 }

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
@@ -193,11 +193,16 @@ namespace OJS.Services.Ui.Business.Implementations
                     .FirstOrDefault();
             });
 
-            var practiceContestParticipantsViewModel = await this.contestParticipantsCacheService.GetPracticeContestParticipantsCount(model.ContestId);
-            participationModel.PracticeParticipantsCount = practiceContestParticipantsViewModel.PracticeParticipantsCount;
-
-            var competeContestParticipantsViewModel = await this.contestParticipantsCacheService.GetCompeteContestParticipantsCount(model.ContestId);
-            participationModel.CompeteParticipantsCount = competeContestParticipantsViewModel.CompeteParticipantsCount;
+            if (model.IsOfficial)
+            {
+                var competeContestParticipantsViewModel = await this.contestParticipantsCacheService.GetCompeteContestParticipantsCount(model.ContestId);
+                participationModel.ParticipantsCount = competeContestParticipantsViewModel.CompeteParticipantsCount;
+            }
+            else
+            {
+                var practiceContestParticipantsViewModel = await this.contestParticipantsCacheService.GetPracticeContestParticipantsCount(model.ContestId);
+                participationModel.ParticipantsCount = practiceContestParticipantsViewModel.PracticeParticipantsCount;
+            }
 
             return participationModel;
         }

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
@@ -33,6 +33,7 @@ namespace OJS.Services.Ui.Business.Implementations
         private readonly IUsersBusinessService usersBusinessService;
         private readonly IUserProviderService userProviderService;
         private readonly IContestValidationService contestValidationService;
+        private readonly IContestParticipantsCacheService contestParticipantsCacheService;
 
         public ContestsBusinessService(
             IContestsDataService contestsData,
@@ -43,7 +44,8 @@ namespace OJS.Services.Ui.Business.Implementations
             IUserProviderService userProviderService,
             IParticipantsBusinessService participantsBusiness,
             IContestCategoriesCacheService contestCategoriesCache,
-            IContestValidationService contestValidationService)
+            IContestValidationService contestValidationService,
+            IContestParticipantsCacheService contestParticipantsCacheService)
         {
             this.contestsData = contestsData;
             this.examGroupsData = examGroupsData;
@@ -54,6 +56,7 @@ namespace OJS.Services.Ui.Business.Implementations
             this.participantsBusiness = participantsBusiness;
             this.contestCategoriesCache = contestCategoriesCache;
             this.contestValidationService = contestValidationService;
+            this.contestParticipantsCacheService = contestParticipantsCacheService;
         }
 
         public async Task<RegisterUserForContestServiceModel> RegisterUserForContest(int id, bool official)
@@ -189,6 +192,11 @@ namespace OJS.Services.Ui.Business.Implementations
                     .Select(x => x.Points)
                     .FirstOrDefault();
             });
+
+            participationModel.ActiveParticipantsCount = this.contestParticipantsCacheService.GetParticipantsCountByContestAndIsOfficial(
+                    model.ContestId,
+                    true);
+            participationModel.TotalParticipantsCount = this.contestParticipantsCacheService.GetParticipantsCountByContest(model.ContestId);
 
             return participationModel;
         }

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
@@ -193,10 +193,11 @@ namespace OJS.Services.Ui.Business.Implementations
                     .FirstOrDefault();
             });
 
-            participationModel.ActiveParticipantsCount = this.contestParticipantsCacheService.GetParticipantsCountByContestAndIsOfficial(
-                    model.ContestId,
-                    true);
-            participationModel.TotalParticipantsCount = this.contestParticipantsCacheService.GetParticipantsCountByContest(model.ContestId);
+            var practiceContestParticipantsViewModel = await this.contestParticipantsCacheService.GetPracticeContestParticipantsCount(model.ContestId);
+            participationModel.PracticeParticipantsCount = practiceContestParticipantsViewModel.PracticeParticipantsCount;
+
+            var competeContestParticipantsViewModel = await this.contestParticipantsCacheService.GetCompeteContestParticipantsCount(model.ContestId);
+            participationModel.CompeteParticipantsCount = competeContestParticipantsViewModel.CompeteParticipantsCount;
 
             return participationModel;
         }

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
@@ -251,13 +251,11 @@ namespace OJS.Services.Ui.Business.Implementations
 
             if (model.IsOfficial)
             {
-                var competeContestParticipantsViewModel = await this.contestParticipantsCacheService.GetCompeteContestParticipantsCount(model.ContestId);
-                participationModel.ParticipantsCount = competeContestParticipantsViewModel.CompeteParticipantsCount;
+                participationModel.ParticipantsCount = await this.contestParticipantsCacheService.GetCompeteContestParticipantsCount(model.ContestId);
             }
             else
             {
-                var practiceContestParticipantsViewModel = await this.contestParticipantsCacheService.GetPracticeContestParticipantsCount(model.ContestId);
-                participationModel.ParticipantsCount = practiceContestParticipantsViewModel.PracticeParticipantsCount;
+                participationModel.ParticipantsCount = await this.contestParticipantsCacheService.GetPracticeContestParticipantsCount(model.ContestId);
             }
 
             return participationModel;

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
@@ -35,17 +35,11 @@ public class ParticipantsBusinessService : IParticipantsBusinessService
         this.datesService = datesService;
     }
 
-    public Task<ContestParticipantsViewModel> GetPracticeParticipantsCount(int contestId)
-        => Task.FromResult(new ContestParticipantsViewModel
-        {
-            PracticeParticipantsCount = this.participantsData.GetAllByContestAndIsOfficial(contestId, false).Count(),
-        });
+    public Task<int> GetPracticeParticipantsCount(int contestId)
+        => this.participantsData.GetAllByContestAndIsOfficial(contestId, false).CountAsync();
 
-    public Task<ContestParticipantsViewModel> GetCompeteParticipantsCount(int contestId)
-        => Task.FromResult(new ContestParticipantsViewModel
-        {
-            CompeteParticipantsCount = this.participantsData.GetAllByContestAndIsOfficial(contestId, true).Count(),
-        });
+    public Task<int> GetCompeteParticipantsCount(int contestId)
+        => this.participantsData.GetAllByContestAndIsOfficial(contestId, true).CountAsync();
 
     public async Task<Participant> CreateNewByContestByUserByIsOfficialAndIsAdmin(
         Contest contest,

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
@@ -35,13 +35,16 @@ public class ParticipantsBusinessService : IParticipantsBusinessService
         this.datesService = datesService;
     }
 
-    public Task<ContestParticipantsViewModel> GetParticipantsCountByContest(int contestId)
+    public Task<ContestParticipantsViewModel> GetPracticeParticipantsCount(int contestId)
         => Task.FromResult(new ContestParticipantsViewModel
         {
-            CompeteParticipantsCount =
-                this.participantsData.GetAllByContestAndIsOfficial(contestId, true).Count(),
-            PracticeParticipantsCount =
-                this.participantsData.GetAllByContestAndIsOfficial(contestId, false).Count(),
+            PracticeParticipantsCount = this.participantsData.GetAllByContestAndIsOfficial(contestId, false).Count(),
+        });
+
+    public Task<ContestParticipantsViewModel> GetCompeteParticipantsCount(int contestId)
+        => Task.FromResult(new ContestParticipantsViewModel
+        {
+            CompeteParticipantsCount = this.participantsData.GetAllByContestAndIsOfficial(contestId, true).Count(),
         });
 
     public async Task<Participant> CreateNewByContestByUserByIsOfficialAndIsAdmin(

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
@@ -14,6 +14,7 @@ using OJS.Services.Common.Models;
 using OJS.Common.Extensions;
 using SharedResource = OJS.Common.Resources.ContestsGeneral;
 using Resource = OJS.Common.Resources.ParticipantsBusiness;
+using OJS.Services.Common.Models.Cache;
 
 public class ParticipantsBusinessService : IParticipantsBusinessService
 {
@@ -33,6 +34,15 @@ public class ParticipantsBusinessService : IParticipantsBusinessService
         this.submissionsData = submissionsData;
         this.datesService = datesService;
     }
+
+    public Task<ContestParticipantsViewModel> GetParticipantsCountByContest(int contestId)
+        => Task.FromResult(new ContestParticipantsViewModel
+        {
+            CompeteParticipantsCount =
+                this.participantsData.GetAllByContestAndIsOfficial(contestId, true).Count(),
+            PracticeParticipantsCount =
+                this.participantsData.GetAllByContestAndIsOfficial(contestId, false).Count(),
+        });
 
     public async Task<Participant> CreateNewByContestByUserByIsOfficialAndIsAdmin(
         Contest contest,

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
@@ -37,11 +37,5 @@ public class ContestParticipationServiceModel : IMapExplicitly
                 s.ParticipationEndTime.HasValue
                     ? (s.ParticipationEndTime.Value - DateTime.UtcNow).TotalMilliseconds
                     : 0))
-            .ForMember(d => d.TotalParticipantsCount, opt => opt.MapFrom(s =>
-                s.Contest.Participants.Count))
-            .ForMember(d => d.ActiveParticipantsCount, opt => opt.MapFrom(s =>
-                s.Contest.Participants.Count(x =>
-                    x.ParticipationStartTime != null && x.ParticipationEndTime != null &&
-                    x.ParticipationStartTime <= DateTime.UtcNow && DateTime.UtcNow < x.ParticipationEndTime)))
             .ForAllOtherMembers(opt => opt.Ignore());
 }

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
@@ -22,9 +22,9 @@ public class ContestParticipationServiceModel : IMapExplicitly
 
     public bool ShouldEnterPassword { get; set; }
 
-    public int TotalParticipantsCount { get; set; }
+    public int CompeteParticipantsCount { get; set; }
 
-    public int ActiveParticipantsCount { get; set; }
+    public int PracticeParticipantsCount { get; set; }
 
     public void RegisterMappings(IProfileExpression configuration)
         => configuration.CreateMap<Participant, ContestParticipationServiceModel>()

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
@@ -22,9 +22,10 @@ public class ContestParticipationServiceModel : IMapExplicitly
 
     public bool ShouldEnterPassword { get; set; }
 
-    public int CompeteParticipantsCount { get; set; }
-
-    public int PracticeParticipantsCount { get; set; }
+    /// <summary>
+    /// Gets or sets the count of participants in the contest taking into consideration if it is compete or practice.
+    /// </summary>
+    public int ParticipantsCount { get; set; }
 
     public void RegisterMappings(IProfileExpression configuration)
         => configuration.CreateMap<Participant, ContestParticipationServiceModel>()


### PR DESCRIPTION
Closes
https://github.com/SoftUni-Internal/exam-systems-issues/issues/842

Linked pull requests from another repos (if any):

**Summary of the changes made**:
1. Cache counting of practice and compete participants
