### PR TITLE
Enable profiler for react

### DIFF
--- a/Docker/Dockerfile.ui
+++ b/Docker/Dockerfile.ui
@@ -21,7 +21,7 @@ COPY Servers/UI/OJS.Servers.Ui/ClientApp /src/Servers/UI/OJS.Servers.Ui/ClientAp
 WORKDIR /src/Servers/UI/OJS.Servers.Ui/ClientApp
 
 RUN yarn run lint
-RUN yarn build
+RUN yarn build --profile
 
 
 # .Net build


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/779

Allows us to use React dev tools extension, but it was disabled for production build. In order to allow it for prod build, the build command had to be changed.
