### PR TITLE
User submissions by mode

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/Controllers/Api/SubmissionsController.cs
+++ b/Servers/UI/OJS.Servers.Ui/Controllers/Api/SubmissionsController.cs
@@ -147,6 +147,20 @@ public class SubmissionsController : BaseApiController
             .ToOkResult();
 
     /// <summary>
+    /// Gets user latest submissions (default number of submissions) by participation mode.
+    /// </summary>
+    /// <param name="isOfficial">Boolean indicating submission participation mode (practice/compete).</param>
+    /// <param name="page">The current page number.</param>
+    /// <returns>A page with submissions containing information about their score and user.</returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(PagedResultResponse<SubmissionForPublicSubmissionsResponseModel>), Status200OK)]
+    public async Task<IActionResult> GetUserSubmissions([FromQuery] bool isOfficial, [FromQuery]int page)
+        => await this.submissionsBusiness
+            .GetUsersLastSubmissions(isOfficial, page)
+            .Map<PagedResultResponse<SubmissionForPublicSubmissionsResponseModel>>()
+            .ToOkResult();
+
+    /// <summary>
     /// Gets all unprocessed submissions.
     /// </summary>
     /// <param name="page">The current page number.</param>

--- a/Servers/UI/OJS.Servers.Ui/Controllers/Api/SubmissionsController.cs
+++ b/Servers/UI/OJS.Servers.Ui/Controllers/Api/SubmissionsController.cs
@@ -153,6 +153,7 @@ public class SubmissionsController : BaseApiController
     /// <param name="page">The current page number.</param>
     /// <returns>A page with submissions containing information about their score and user.</returns>
     [HttpGet]
+    [Authorize]
     [ProducesResponseType(typeof(PagedResultResponse<SubmissionForPublicSubmissionsResponseModel>), Status200OK)]
     public async Task<IActionResult> GetUserSubmissions([FromQuery] bool isOfficial, [FromQuery]int page)
         => await this.submissionsBusiness

--- a/Services/UI/OJS.Services.Ui.Business/ISubmissionsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/ISubmissionsBusinessService.cs
@@ -33,6 +33,8 @@
 
         Task<PagedResult<SubmissionForPublicSubmissionsServiceModel>> GetPublicSubmissions(SubmissionForPublicSubmissionsServiceModel model);
 
+        Task<PagedResult<SubmissionForPublicSubmissionsServiceModel>> GetUsersLastSubmissions(bool isOfficial, int page);
+
         Task<PagedResult<SubmissionForPublicSubmissionsServiceModel>> GetProcessingSubmissions(int page);
 
         Task<PagedResult<SubmissionForPublicSubmissionsServiceModel>> GetPendingSubmissions(int page);

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/SubmissionsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/SubmissionsBusinessService.cs
@@ -508,6 +508,7 @@ public class SubmissionsBusinessService : ISubmissionsBusinessService
 
         var userParticipantsIds = await this.participantsDataService
             .GetAllByUser(user.Id)
+            .Where(p => p.IsOfficial == isOfficial)
             .Select(p => p.Id)
             .ToEnumerableAsync();
 

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/SubmissionsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/SubmissionsBusinessService.cs
@@ -25,6 +25,7 @@ using SoftUni.Common.Extensions;
 using OJS.Services.Ui.Business.Validations.Implementations.Contests;
 using OJS.Services.Ui.Models.Contests;
 using OJS.Services.Common;
+using OJS.Services.Infrastructure.Extensions;
 using OJS.Data.Models.Problems;
 using OJS.Services.Common.Models.Submissions.ExecutionContext;
 using OJS.Services.Common.Models.Submissions;
@@ -499,6 +500,22 @@ public class SubmissionsBusinessService : ISubmissionsBusinessService
             DefaultSubmissionsPerPage);
 
         return modelResult;
+    }
+
+    public async Task<PagedResult<SubmissionForPublicSubmissionsServiceModel>> GetUsersLastSubmissions(bool isOfficial, int page)
+    {
+        var user = this.userProviderService.GetCurrentUser();
+
+        var userParticipantsIds = await this.participantsDataService
+            .GetAllByUser(user.Id)
+            .Select(p => p.Id)
+            .ToEnumerableAsync();
+
+        return await this.submissionsData
+            .GetLatestSubmissionsByUserParticipations<SubmissionForPublicSubmissionsServiceModel>(
+                userParticipantsIds.MapCollection<int?>(),
+                DefaultSubmissionsPerPage,
+                page);
     }
 
     public async Task<PagedResult<SubmissionForPublicSubmissionsServiceModel>> GetProcessingSubmissions(int page)

--- a/Services/UI/OJS.Services.Ui.Data/ISubmissionsDataService.cs
+++ b/Services/UI/OJS.Services.Ui.Data/ISubmissionsDataService.cs
@@ -16,6 +16,11 @@ public interface ISubmissionsDataService : IDataService<Submission>
 
     Task<PagedResult<TServiceModel>> GetLatestSubmissions<TServiceModel>(int submissionsPerPage, int pageNumber);
 
+    Task<PagedResult<TServiceModel>> GetLatestSubmissionsByUserParticipations<TServiceModel>(
+        IEnumerable<int?> userParticipantsIds,
+        int submissionsPerPage,
+        int pageNumber);
+
     Task<int> GetTotalSubmissionsCount();
 
     Task<TServiceModel> GetParticipantBySubmission<TServiceModel>(int submissionId);

--- a/Services/UI/OJS.Services.Ui.Data/Implementations/SubmissionsDataService.cs
+++ b/Services/UI/OJS.Services.Ui.Data/Implementations/SubmissionsDataService.cs
@@ -41,6 +41,18 @@ public class SubmissionsDataService : DataService<Submission>, ISubmissionsDataS
                 .MapCollection<TServiceModel>()
                 .ToPagedResultAsync(submissionsPerPage, pageNumber);
 
+    // TODO: https://github.com/SoftUni-Internal/exam-systems-issues/issues/903
+    public async Task<PagedResult<TServiceModel>> GetLatestSubmissionsByUserParticipations<TServiceModel>(
+        IEnumerable<int?> userParticipantsIds,
+        int submissionsPerPage,
+        int pageNumber)
+            => await this.GetQuery(
+                    filter: s => !s.IsDeleted && userParticipantsIds.Contains(s.ParticipantId!),
+                    orderBy: s => s.Id,
+                    descending: true)
+                .MapCollection<TServiceModel>()
+                .ToPagedResultAsync(submissionsPerPage, pageNumber);
+
     public async Task<int> GetTotalSubmissionsCount()
         => await this.DbSet
                     .CountAsync();


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/899

Added endpoint that returns logged in user last N submissions filtered by mode (practice/compete)

Endpoint: `{ui_url}/api/Submissions/GetUserSubmissions?isOfficial=false&page=2`