### PR TITLE
Display message and retest button, when tests changed for problem

### DIFF
--- a/Servers/UI/OJS.Servers.Ui.Models/Submissions/Details/SubmissionDetailsResponseModel.cs
+++ b/Servers/UI/OJS.Servers.Ui.Models/Submissions/Details/SubmissionDetailsResponseModel.cs
@@ -38,5 +38,9 @@
         public DateTime? ModifiedOn { get; set; }
 
         public DateTime? StartedExecutionOn { get; set; }
+
+        public string? ProcessingComment { get; set; }
+
+        public int TotalTests { get; set; }
     }
 }

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/submissions/details/SubmissionDetails.module.scss
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/submissions/details/SubmissionDetails.module.scss
@@ -126,3 +126,17 @@
   margin-top: 10px;
   margin-right: 20px;
 }
+
+.testChangesWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  border: 2px solid;
+  font-size: 16px;
+  padding: 1rem;
+  border-color: colors.$background-color-btn-primary;
+  border-radius: 12px;
+  background-color: colors.$background-color-btn-primary;
+  font-family: fonts.$font-family-lato;
+  margin-bottom: 1rem;
+}

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/submissions/details/SubmissionDetails.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/submissions/details/SubmissionDetails.tsx
@@ -192,6 +192,24 @@ const SubmissionDetails = () => {
         [ currentSubmission, getSubmissionDetailsResults ],
     );
 
+    const renderRetestButton = useCallback(
+        () => {
+            if (!canAccessAdministration) {
+                return null;
+            }
+
+            return (
+                <LinkButton
+                  type={LinkButtonType.secondary}
+                  size={ButtonSize.medium}
+                  to={getAdministrationRetestSubmissionInternalUrl()}
+                  text="Retest"
+                  className={styles.retestButton}
+                />
+            );
+        },
+        [ canAccessAdministration, getAdministrationRetestSubmissionInternalUrl ],
+    );
     const renderButtonsSection = useCallback(() => (
         <div className={styles.buttonsSection}>
             <Button
@@ -200,17 +218,32 @@ const SubmissionDetails = () => {
               type={ButtonType.secondary}
               className={styles.submissionReloadBtn}
             />
-            { canAccessAdministration && (
-                <LinkButton
-                  type={LinkButtonType.secondary}
-                  size={ButtonSize.medium}
-                  to={getAdministrationRetestSubmissionInternalUrl()}
-                  text="Retest"
-                  className={styles.retestButton}
-                />
-            )}
+            {renderRetestButton()}
         </div>
-    ), [ canAccessAdministration, getAdministrationRetestSubmissionInternalUrl, handleReloadClick ]);
+    ), [ handleReloadClick, renderRetestButton ]);
+
+    const renderTestsChangeMessage = useCallback(() => (
+        currentSubmission?.testRuns.length === 0 &&
+            currentSubmission.isCompiledSuccessfully &&
+            currentSubmission.totalTests > 0 &&
+            !currentSubmission.processingComment
+            ? (
+                <div className={styles.testChangesWrapper}>
+                    <p>
+                        The input/output data changed. Your (
+                        {currentSubmission.points}
+                        /
+                        {currentSubmission.problem.maximumPoints}
+                        )
+                        submission is now outdated.
+                        Click &quot;Retest&quot; to resubmit your solution for re-evaluation against the new test cases.
+                        Your score may change.
+                    </p>
+                    {renderRetestButton()}
+                </div>
+            )
+            : ''
+    ), [ currentSubmission, renderRetestButton ]);
 
     const renderSubmissionInfo = useCallback(
         () => {
@@ -391,6 +424,9 @@ const SubmissionDetails = () => {
 
     return (
         <>
+            <div>
+                {renderTestsChangeMessage()}
+            </div>
             <div className={styles.detailsWrapper}>
                 {refreshableSubmissionsList()}
                 {codeEditor()}

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/submissions/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/submissions/types.ts
@@ -37,6 +37,7 @@ interface ISubmissionType {
     createdOn: Date;
     modifiedOn?: Date;
     startedExecutionOn?: Date;
+    processingComment: string;
 }
 
 interface ITestRunDetailsType extends ITestRunType {
@@ -48,6 +49,7 @@ interface ITestRunDetailsType extends ITestRunType {
 interface ISubmissionDetailsType extends ISubmissionType {
     testRuns: ITestRunDetailsType[];
     user: IUserProfileType;
+    totalTests : number;
 }
 
 interface ISubmissionDetails {

--- a/Services/UI/OJS.Services.Ui.Models/Submissions/SubmissionDetailsServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Submissions/SubmissionDetailsServiceModel.cs
@@ -45,6 +45,10 @@
 
         public DateTime? StartedExecutionOn { get; set; }
 
+        public string? ProcessingComment { get; set; }
+
+        public int TotalTests { get; set; }
+
         public void RegisterMappings(IProfileExpression configuration)
             => configuration.CreateMap<Submission, SubmissionDetailsServiceModel>()
                 .ForMember(s => s.User, opt => opt.MapFrom(s => s.Participant!.User))
@@ -63,6 +67,10 @@
                 .ForMember(d => d.IsOfficial, opt => opt.MapFrom(s =>
                     s.Participant!.IsOfficial))
                 .ForMember(d => d.ByteContent, opt => opt.MapFrom(s =>
-                    s.Content));
+                    s.Content))
+                .ForMember(d => d.TotalTests, opt => opt.MapFrom(s =>
+                    s.Problem != null
+                        ? s.Problem.Tests.Count
+                        : 0));
     }
 }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/874

Added new function which renders, specific message and "Retest" button, on the submission details page, when tests for the submission's problem are changed.