### PR TITLE
New fixing active remaning time for contests

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
@@ -111,7 +111,6 @@ interface IContestType {
     resultsArePubliclyVisible: boolean;
     hasContestPassword: boolean;
     hasPracticePassword: boolean;
-    remainingTimeInMilliseconds: number;
     userIsAdminOrLecturerInContest: boolean;
     userCanCompete: boolean;
     userIsParticipant: false;

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
@@ -166,7 +166,7 @@ interface IStartParticipationResponseType {
     participantId: number;
     contestIsCompete: boolean;
     lastSubmissionTime: Date;
-    remainingTimeInMilliseconds: number;
+    endDateTimeForParticipantOrContest: Date | null;
     userSubmissionsTimeLimit: number;
     participantsCount: number;
 }

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/countdown/Countdown.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/countdown/Countdown.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { convertToTwoDigitValues, secondsToFullTime } from '../../../utils/dates';
+import Text, { TextType } from '../text/Text';
 
 enum Metric {
     seconds = 1,
@@ -24,20 +25,51 @@ interface ICountdownProps {
     handleOnCountdownChange?: (seconds: number) => void;
 }
 
+const remainingTimeClassName = 'remainingTime';
 const defaultRender = (remainingTime: ICountdownRemainingType) => {
-    const { hours, minutes, seconds } = convertToTwoDigitValues(remainingTime);
+    const { days, hours, minutes, seconds } = convertToTwoDigitValues(remainingTime);
+
+    if (!Number(days)) {
+        return (
+            <p className={remainingTimeClassName}>
+                Remaining time:
+                {' '}
+                <Text type={TextType.Bold}>
+                    {' '}
+                    {hours}
+                    {' '}
+                    h,
+                    {' '}
+                    {minutes}
+                    {' '}
+                    m,
+                    {' '}
+                    {seconds}
+                    {' '}
+                    s
+                </Text>
+            </p>
+        );
+    }
 
     return (
-        <p>
+        <p className={remainingTimeClassName}>
             Remaining time:
             {' '}
-            <span>
+            <Text type={TextType.Bold}>
+                {' '}
+                {days}
+                {' '}
+                d,
+                {' '}
                 {hours}
-                :
+                {' '}
+                h,
+                {' '}
                 {minutes}
-                :
-                {seconds}
-            </span>
+                {' '}
+                m
+            </Text>
         </p>
     );
 };
@@ -70,8 +102,6 @@ const Countdown = ({
     useEffect(() => {
         if (remainingInSeconds < 0) {
             handleOnCountdownEnd();
-
-            return () => null;
         }
 
         const timer = setTimeout(decreaseRemainingTime, 1000);

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/home-contests/contest-card/ContestCard.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/home-contests/contest-card/ContestCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import isNil from 'lodash/isNil';
 
@@ -7,7 +7,7 @@ import { IIndexContestsType } from '../../../common/types';
 import { useAppUrls } from '../../../hooks/use-app-urls';
 import { useModal } from '../../../hooks/use-modal';
 import concatClassNames from '../../../utils/class-names';
-import { convertToSecondsRemaining } from '../../../utils/dates';
+import { convertToSecondsRemaining, getCurrentTimeInUTC } from '../../../utils/dates';
 import { Button, ButtonSize, ButtonState, LinkButton, LinkButtonType } from '../../guidelines/buttons/Button';
 import Countdown, { Metric } from '../../guidelines/countdown/Countdown';
 import LockIcon from '../../guidelines/icons/LockIcon';
@@ -49,6 +49,30 @@ const ContestCard = ({ contest }: IContestCardProps) => {
     const { getParticipateInContestUrl, getContestDetailsUrl } = useAppUrls();
     const { actions: { setIsShowing } } = useModal();
     const navigate = useNavigate();
+    const [ competeTimeHasExpired, setCompeteTimeHasExpired ] = useState(false);
+    const [ practiceTimeHasExpired, setPracticeTimeHasExpired ] = useState(false);
+
+    const endDate = !isNil(endTime) && new Date(endTime) >= getCurrentTimeInUTC()
+        ? endTime
+        : !isNil(practiceEndTime)
+            ? practiceEndTime
+            : null;
+
+    const handleCountdownEnd = useCallback(
+        () => {
+            if (!isNil(endDate) && new Date(endDate) <= getCurrentTimeInUTC()) {
+                if (canBeCompeted) {
+                    setCompeteTimeHasExpired(true);
+                    return;
+                }
+
+                if (canBePracticed) {
+                    setPracticeTimeHasExpired(true);
+                }
+            }
+        },
+        [ endDate, canBeCompeted, canBePracticed ],
+    );
 
     const participationType = useMemo(
         () => canBeCompeted
@@ -59,15 +83,7 @@ const ContestCard = ({ contest }: IContestCardProps) => {
 
     const renderCountdown = useCallback(
         () => {
-            const endDate = canBeCompeted
-                ? endTime
-                : practiceEndTime;
-
-            if (canBePracticed && isNil(practiceEndTime) && isNil(endDate)) {
-                return <p>No practice end time.</p>;
-            }
-
-            if ((!canBePracticed && !canBeCompeted) || isNil(endDate)) {
+            if (isNil(endDate) || new Date(endDate) < getCurrentTimeInUTC()) {
                 return null;
             }
 
@@ -76,10 +92,11 @@ const ContestCard = ({ contest }: IContestCardProps) => {
                   key={id}
                   duration={convertToSecondsRemaining(new Date(endDate))}
                   metric={Metric.seconds}
+                  handleOnCountdownEnd={handleCountdownEnd}
                 />
             );
         },
-        [ canBeCompeted, canBePracticed, endTime, id, practiceEndTime ],
+        [ endDate, handleCountdownEnd, id ],
     );
 
     const renderContestLockIcon = useCallback(
@@ -142,7 +159,7 @@ const ContestCard = ({ contest }: IContestCardProps) => {
                   onClick={() => setIsShowingAndNavigateToContest()}
                   text="Compete"
                   state={
-                        canBeCompeted
+                        canBeCompeted && !competeTimeHasExpired
                             ? ButtonState.enabled
                             : ButtonState.disabled
                     }
@@ -157,7 +174,7 @@ const ContestCard = ({ contest }: IContestCardProps) => {
                   text="Practice"
                   type={LinkButtonType.secondary}
                   state={
-                        canBePracticed
+                        canBePracticed && !practiceTimeHasExpired
                             ? ButtonState.enabled
                             : ButtonState.disabled
                     }

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
@@ -49,7 +49,7 @@ interface ICurrentContestContext {
         requirePassword: boolean | null;
         contestPasswordError: IErrorDataType | null;
         isPasswordValid: boolean | null;
-        remainingTimeInMilliseconds: number;
+        endDateTimeForParticipantOrContest: Date | null;
         userSubmissionsTimeLimit: number;
         participantsCount: number;
         isSubmitAllowed: boolean;
@@ -86,7 +86,6 @@ const defaultState = {
         maxScore: 0,
         isOfficial: false,
         isPasswordValid: false,
-        remainingTimeInMilliseconds: 0.0,
         userSubmissionsTimeLimit: 0,
         participantsCount: 0,
         isUserParticipant: false,
@@ -132,7 +131,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
     const [ contestPasswordError, setContestPasswordError ] = useState<IErrorDataType | null>(null);
     const [ isPasswordValid, setIsPasswordValid ] = useState<boolean>(defaultState.state.isPasswordValid);
     const [ userSubmissionsTimeLimit, setUserSubmissionsTimeLimit ] = useState<number>(0);
-    const [ remainingTimeInMilliseconds, setRemainingTimeInMilliseconds ] = useState(defaultState.state.remainingTimeInMilliseconds);
+    const [ endDateTimeForParticipantOrContest, setEndDateTimeForParticipantOrContest ] = useState<Date | null>(null);
     const [ participantsCount, setParticipantsCount ] = useState(defaultState.state.participantsCount);
     const [ isSubmitAllowed, setIsSubmitAllowed ] = useState<boolean>(true);
     const [ contestError, setContestError ] = useState<IErrorDataType | null>(null);
@@ -406,14 +405,14 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 contest: newContest,
                 contestIsCompete,
                 participantId: currentParticipantId,
-                remainingTimeInMilliseconds: newRemainingTimeInMilliseconds,
+                endDateTimeForParticipantOrContest: newEndDateTimeForParticipantOrContest,
                 participantsCount: newParticipantsCount,
             } = startContestData;
 
             setContest(newContest);
             setIsOfficial(contestIsCompete);
             setParticipantId(currentParticipantId);
-            setRemainingTimeInMilliseconds(newRemainingTimeInMilliseconds);
+            setEndDateTimeForParticipantOrContest(newEndDateTimeForParticipantOrContest);
             setUserSubmissionsTimeLimit(startContestData.userSubmissionsTimeLimit);
             setParticipantsCount(newParticipantsCount);
 
@@ -461,7 +460,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 requirePassword,
                 contestPasswordError,
                 isPasswordValid,
-                remainingTimeInMilliseconds,
+                endDateTimeForParticipantOrContest,
                 userSubmissionsTimeLimit,
                 participantsCount,
                 isSubmitAllowed,
@@ -497,7 +496,7 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
             isPasswordValid,
             maxScore,
             registerParticipant,
-            remainingTimeInMilliseconds,
+            endDateTimeForParticipantOrContest,
             userSubmissionsTimeLimit,
             requirePassword,
             score,

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -1,4 +1,4 @@
-import { intervalToDuration } from 'date-fns';
+import { differenceInDays, intervalToDuration } from 'date-fns';
 import moment from 'moment';
 
 const defaultDateTimeFormat = 'HH:MM, DD/MMM/yyyy';
@@ -21,25 +21,36 @@ const formatDate = (
     ? preciseFormatDate(date, formatString)
     : moment(date).utc(true).local().fromNow());
 
+const getLocalDateTimeInUTC = () => {
+    const now = new Date();
+    return new Date(now.getTime() + now.getTimezoneOffset() * 60000);
+};
 const convertToSecondsRemaining = (date: Date) => {
-    const { days, hours, minutes, seconds } = intervalToDuration({
-        start: new Date(),
+    const currentDate = getLocalDateTimeInUTC();
+    const { hours, minutes, seconds } = intervalToDuration({
+        start: currentDate,
         end: date,
     });
 
-    const daysRemaining = days ?? 0;
+    const daysRemaining = differenceInDays(date, currentDate);
 
     const hoursRemaining = daysRemaining * 24 + (hours ?? 0);
+
     const minutesRemaining = hoursRemaining * 60 + (minutes ?? 0);
 
     return minutesRemaining * 60 + (seconds ?? 0);
 };
 
+// This function converts a given duration in seconds into a time object that includes
+// days, hours, minutes, and seconds.
+// The function first calculates the number of whole days within the duration
+// The remaining seconds are computed using the modulus operator (%)
+// The function 'intervalToDuration' is then used to break down the remaining seconds into h, m, s
 const secondsToFullTime = (duration: number) => {
-    const { days: daysInitial, hours: hoursInitial, minutes: minutesInitial, seconds: secondsInitial } =
-        intervalToDuration({ start: 0, end: duration * 1000 });
-
-    const days = daysInitial ?? 0;
+    const days = Math.floor(duration / 86400); // Number of seconds in a day: 86400 (60 seconds * 60 minutes * 24 hours)
+    const remainingSeconds = duration % 86400;
+    const { hours: hoursInitial, minutes: minutesInitial, seconds: secondsInitial } =
+        intervalToDuration({ start: 0, end: remainingSeconds * 1000 });
 
     const hours = hoursInitial ?? 0;
 
@@ -51,16 +62,21 @@ const secondsToFullTime = (duration: number) => {
 };
 
 interface IConvertToTwoDigitValuesParamType {
+    days: number;
     hours: number;
     minutes: number;
     seconds: number;
 }
 
 const convertToTwoDigitValues = ({
+    days: daysValue,
     hours: hoursValue,
     minutes: minutesValue,
     seconds: secondsValue,
 }: IConvertToTwoDigitValuesParamType) => {
+    const days = daysValue >= 10
+        ? daysValue.toString()
+        : `0${daysValue}`;
     const hours = hoursValue >= 10
         ? hoursValue.toString()
         : `0${hoursValue}`;
@@ -74,6 +90,7 @@ const convertToTwoDigitValues = ({
         : `0${secondsValue}`;
 
     return {
+        days,
         hours,
         minutes,
         seconds,
@@ -87,6 +104,7 @@ export default {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
+    getLocalDateTimeInUTC,
 };
 
 export {
@@ -96,4 +114,5 @@ export {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
+    getLocalDateTimeInUTC,
 };

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -21,7 +21,7 @@ const formatDate = (
     ? preciseFormatDate(date, formatString)
     : moment(date).utc(true).local().fromNow());
 
-const getCurrentTimeInUtc = () => {
+const getCurrentTimeInUTC = () => {
     const now = moment().utc();
     return new Date(
         now.year(),
@@ -34,7 +34,7 @@ const getCurrentTimeInUtc = () => {
     );
 };
 const convertToSecondsRemaining = (date: Date) => {
-    const currentDate = getCurrentTimeInUtc();
+    const currentDate = getCurrentTimeInUTC();
     const { hours, minutes, seconds } = intervalToDuration({
         start: currentDate,
         end: date,
@@ -113,7 +113,7 @@ export default {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getCurrentTimeInUtc,
+    getCurrentTimeInUTC,
 };
 
 export {
@@ -123,5 +123,5 @@ export {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getCurrentTimeInUtc,
+    getCurrentTimeInUTC,
 };

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -21,7 +21,7 @@ const formatDate = (
     ? preciseFormatDate(date, formatString)
     : moment(date).utc(true).local().fromNow());
 
-const getCurrentTimeInUTC = () => {
+const getCurrentTimeInUtc = () => {
     const now = moment().utc();
     return new Date(
         now.year(),
@@ -34,7 +34,7 @@ const getCurrentTimeInUTC = () => {
     );
 };
 const convertToSecondsRemaining = (date: Date) => {
-    const currentDate = getCurrentTimeInUTC();
+    const currentDate = getCurrentTimeInUtc();
     const { hours, minutes, seconds } = intervalToDuration({
         start: currentDate,
         end: date,
@@ -113,7 +113,7 @@ export default {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getCurrentTimeInUTC,
+    getCurrentTimeInUtc,
 };
 
 export {
@@ -123,5 +123,5 @@ export {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getCurrentTimeInUTC,
+    getCurrentTimeInUtc,
 };

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -21,12 +21,20 @@ const formatDate = (
     ? preciseFormatDate(date, formatString)
     : moment(date).utc(true).local().fromNow());
 
-const getLocalDateTimeInUTC = () => {
-    const now = new Date();
-    return new Date(now.getTime() + now.getTimezoneOffset() * 60000);
+const getCurrentTimeInUtc = () => {
+    const now = moment().utc();
+    return new Date(
+        now.year(),
+        now.month(),
+        now.date(),
+        now.hour(),
+        now.minute(),
+        now.second(),
+        now.millisecond(),
+    );
 };
 const convertToSecondsRemaining = (date: Date) => {
-    const currentDate = getLocalDateTimeInUTC();
+    const currentDate = getCurrentTimeInUtc();
     const { hours, minutes, seconds } = intervalToDuration({
         start: currentDate,
         end: date,
@@ -104,7 +112,7 @@ export default {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getLocalDateTimeInUTC,
+    getCurrentTimeInUtc,
 };
 
 export {
@@ -114,5 +122,5 @@ export {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getLocalDateTimeInUTC,
+    getCurrentTimeInUtc,
 };

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -55,7 +55,8 @@ const convertToSecondsRemaining = (date: Date) => {
 // The remaining seconds are computed using the modulus operator (%)
 // The function 'intervalToDuration' is then used to break down the remaining seconds into h, m, s
 const secondsToFullTime = (duration: number) => {
-    const days = Math.floor(duration / 86400); // Number of seconds in a day: 86400 (60 seconds * 60 minutes * 24 hours)
+    // Number of seconds in a day: 86400 (60 seconds * 60 minutes * 24 hours)
+    const days = Math.floor(duration / 86400);
     const remainingSeconds = duration % 86400;
     const { hours: hoursInitial, minutes: minutesInitial, seconds: secondsInitial } =
         intervalToDuration({ start: 0, end: remainingSeconds * 1000 });

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -21,7 +21,7 @@ const formatDate = (
     ? preciseFormatDate(date, formatString)
     : moment(date).utc(true).local().fromNow());
 
-const getCurrentTimeInUtc = () => {
+const getCurrentTimeInUTC = () => {
     const now = moment().utc();
     return new Date(
         now.year(),
@@ -34,7 +34,7 @@ const getCurrentTimeInUtc = () => {
     );
 };
 const convertToSecondsRemaining = (date: Date) => {
-    const currentDate = getCurrentTimeInUtc();
+    const currentDate = getCurrentTimeInUTC();
     const { hours, minutes, seconds } = intervalToDuration({
         start: currentDate,
         end: date,
@@ -113,7 +113,7 @@ export default {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getCurrentTimeInUtc,
+    getCurrentTimeInUtc: getCurrentTimeInUTC,
 };
 
 export {
@@ -123,5 +123,5 @@ export {
     calculateTimeUntil,
     convertToSecondsRemaining,
     convertToTwoDigitValues,
-    getCurrentTimeInUtc,
+    getCurrentTimeInUTC,
 };

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ParticipantsBusinessService.cs
@@ -49,7 +49,7 @@ public class ParticipantsBusinessService : IParticipantsBusinessService
     {
         var participant = new Participant(contest.Id, userId, isOfficial) { Contest = contest };
 
-        var utcNow = this.datesService.GetUtcNow();
+        var utcNow = DateTime.SpecifyKind(this.datesService.GetUtcNow(), DateTimeKind.Unspecified);
         if (isOfficial && contest.IsOnlineExam)
         {
             participant.ParticipationStartTime = utcNow;

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestParticipationServiceModel.cs
@@ -18,7 +18,7 @@ public class ContestParticipationServiceModel : IMapExplicitly
 
     public int? UserSubmissionsTimeLimit { get; set; }
 
-    public double? RemainingTimeInMilliseconds { get; set; }
+    public DateTime? EndDateTimeForParticipantOrContest { get; set; }
 
     public bool ShouldEnterPassword { get; set; }
 
@@ -34,9 +34,13 @@ public class ContestParticipationServiceModel : IMapExplicitly
                 s.Submissions.Any()
                     ? (DateTime?)s.Submissions.Max(x => x.CreatedOn)
                     : null))
-            .ForMember(d => d.RemainingTimeInMilliseconds, opt => opt.MapFrom(s =>
+            .ForMember(d => d.EndDateTimeForParticipantOrContest, opt => opt.MapFrom(s =>
                 s.ParticipationEndTime.HasValue
-                    ? (s.ParticipationEndTime.Value - DateTime.UtcNow).TotalMilliseconds
-                    : 0))
+                ? s.ParticipationEndTime
+                : s.Contest.EndTime.HasValue && s.Contest.EndTime >= DateTime.UtcNow
+                    ? s.Contest.EndTime
+                    : s.Contest.PracticeEndTime.HasValue
+                        ? s.Contest.PracticeEndTime
+                        : null))
             .ForAllOtherMembers(opt => opt.Ignore());
 }

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestServiceModel.cs
@@ -15,7 +15,7 @@ public class ContestServiceModel : IMapExplicitly
 
     public string Name { get; set; } = null!;
 
-    public int Type { get; set; }
+    public ContestType Type { get; set; }
 
     public int? CategoryId { get; set; }
 
@@ -54,8 +54,6 @@ public class ContestServiceModel : IMapExplicitly
     public int PracticeParticipants { get; set; }
 
     public int ProblemsCount { get; set; }
-
-    public ContestType ContestType { get; set; }
 
     public IEnumerable<SubmissionTypeServiceModel> AllowedSubmissionTypes { get; set; } = null!;
 
@@ -152,19 +150,6 @@ public class ContestServiceModel : IMapExplicitly
 
     public bool HasPracticePassword => this.PracticePassword != null;
 
-    public double? RemainingTimeInMilliseconds
-    {
-        get
-        {
-            if (this.EndTime.HasValue)
-            {
-                return (this.EndTime.Value - DateTime.Now).TotalMilliseconds;
-            }
-
-            return null;
-        }
-    }
-
     public bool UserIsAdminOrLecturerInContest { get; set; }
 
     public bool UserCanCompete { get; set; }
@@ -190,7 +175,7 @@ public class ContestServiceModel : IMapExplicitly
             .ForMember(
                 d => d.ProblemsCount,
                 opt => opt.MapFrom(s => s.ProblemGroups.SelectMany(pg => pg.Problems).Count(p => !p.IsDeleted)))
-            .ForMember(d => d.ContestType, opt => opt.MapFrom(s => s.Type))
+            .ForMember(d => d.Type, opt => opt.MapFrom(s => s.Type))
             .ForMember(
                 d => d.AllowedSubmissionTypes,
                 opt =>


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/746

New PR is create for the issue since previous had too many merge conflicts.
Old PR: https://github.com/SoftUni-Internal/OpenJudgeSystem/pull/778

Summary of the changes made:

1. Removing unused property from ContestServiceModel
2. Removing remainingTimeInMilliseconds property from ContestParticipationServiceModel and replacing it with a DateTime EndDateTimeForParticipantOrContest with the needed changes in the RegisterMappings
3. Adding two state variables for the compete and practice buttons as well as handleOnCountdownEnd menthod in Contest Card and changes to rendering countdown logic
4. Removing some logic from Contest and reusing available renderCountDown logic from Countdown. Contest.tsx passes the Date variable endDateTimeForParticipantOrContest to Countdown and all calculations are not deligated to dates.ts and Countdown.
5. Changes to default render to display days, hours, minutes if days are available, if not hours, minutes, seconds. Adding logic from Contest to Countdown. Adding renderTimeOut function to display 0 values for when countdown has ended.
6. Adding a function to convert the local Data variable to UTC time. Adding daysRemaning variable in convertToSecondsRemaining. Changing the logic in secondToFulltime (comment included). Adding days variable to convertToTwoDigitValues
7. Adding endDateTimeForParticipantOrContest to ICurrentContestContext and IStartParticipationResponseType

