### PR TITLE
Fix contest mapping

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Controllers/CompeteController.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Controllers/CompeteController.cs
@@ -218,15 +218,15 @@
                 return this.RedirectToAction(c => c.NewContestIp(id));
             }
 
+            var contestViewModel = this.cacheService.GetOrSet<ContestViewModel>(
+                string.Format(CacheConstants.ContestView, participant.ContestId),
+                () => { return ContestViewModel.FromContest.Compile()(participant.Contest); });
+
             var participantViewModel = new ParticipantViewModel(
                 participant,
                 official,
-                isUserAdminOrLecturerInContest)
-            {
-                Contest = this.cacheService.GetOrSet<ContestViewModel>(
-                    string.Format(CacheConstants.ContestView, participant.ContestId),
-                     () => { return ContestViewModel.FromContest.Compile()(participant.Contest); })
-            };
+                isUserAdminOrLecturerInContest,
+                contestViewModel);
 
             this.ViewBag.CompeteType = official ? CompeteActionName : PracticeActionName;
             this.ViewBag.IsUserAdminOrLecturer = isUserAdminOrLecturerInContest;

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Participants/ParticipantViewModel.cs
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/ViewModels/Participants/ParticipantViewModel.cs
@@ -10,9 +10,9 @@
     {
         private readonly DateTime? participationEndTime;
 
-        public ParticipantViewModel(Participant participant, bool official, bool isAdminOrLecturer)
+        public ParticipantViewModel(Participant participant, bool official, bool isAdminOrLecturer,ContestViewModel contest)
         {
-            this.Contest = new ContestViewModel();
+            this.Contest = contest;
             this.LastSubmissionTime = participant.Submissions.Any()
                 ? (DateTime?)participant.Submissions.Max(x => x.CreatedOn)
                 : null;


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/925

Reason:
Conditional statement, in which the problems are filtrated, was passing before maping of the Contest property.

Changes:
Contest is passed in the constructor of the ParticipantViewModel,
