### PR TITLE
Display submission type in Submission details view

### DIFF
--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
@@ -7,7 +7,6 @@
 
 @using Resource = Resources.Areas.Contests.Views.SubmissionsView
 @using AdministrationResource = Resources.Areas.Administration.AdministrationGeneral
-
 @model OJS.Web.Areas.Contests.ViewModels.Submissions.SubmissionDetailsViewModel
 
 @{
@@ -77,7 +76,7 @@
             @if (Model.UserHasAdminPermission)
             {
                 <div>
-                    <p><strong>Submission TypeId:</strong> @Model.SubmissionType.Id</p>
+                    <p><strong>Submission Type Name:</strong> @Model.SubmissionType.ExecutionStrategyType</p>
                 </div>
             }
         </div>

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
@@ -93,10 +93,9 @@ else
             if (Model.UserHasAdminPermission)
             {
                 <pre>@Resource.Exception_type: @Model.ExceptionType  
-            @Model.ExecutionComment
-            </pre>
+                     @Model.ExecutionComment
+                </pre>
             }
-
         }
     }
     if (!Model.IsCompiledSuccessfully)

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
@@ -21,6 +21,7 @@
 @section styles {
     @Styles.Render("~/Content/CodeMirror/codemirror")
     @Styles.Render("~/Content/CodeMirror/codemirrormerge")
+    @Styles.Render("~/Content/css/Submissions/SubmissionDetails.css")
 }
 
 @section scripts {
@@ -69,25 +70,19 @@
             @Html.HiddenFor(m => m.Id)
             <input type="submit" class="btn btn-sm btn-primary" value=@Resource.Retest />
         }
+        <div class="submission-type-box">
+            <div>
+                <p><strong>Submission Type:</strong> @Model.SubmissionType.Name</p>
+            </div>
+            @if (Model.UserHasAdminPermission)
+            {
+                <div>
+                    <p><strong>Submission TypeId:</strong> @Model.SubmissionType.Id</p>
+                </div>
+            }
+        </div>
     }
 </div>
-
-@if (Model.UserHasAdminPermission)
-{
-    <div class="clearfix"></div>
-    if (!string.IsNullOrWhiteSpace(Model.ProcessingComment))
-    {
-        <h2>@Resource.Execution_result:</h2>
-        <pre>@Model.ProcessingComment</pre>
-        if (Model.UserHasAdminPermission)
-        {
-            <pre>@Resource.Exception_type: @Model.ExceptionType  
-            @Model.ExecutionComment
-            </pre>
-        }
-
-    }
-}
 
 @if (Model.IsDeleted)
 {
@@ -100,6 +95,22 @@
 }
 else
 {
+    if (Model.UserHasAdminPermission)
+    {
+        <div class="clearfix"></div>
+        if (!string.IsNullOrWhiteSpace(Model.ProcessingComment))
+        {
+            <h2>@Resource.Execution_result:</h2>
+            <pre>@Model.ProcessingComment</pre>
+            if (Model.UserHasAdminPermission)
+            {
+                <pre>@Resource.Exception_type: @Model.ExceptionType  
+            @Model.ExecutionComment
+            </pre>
+            }
+
+        }
+    }
     if (!Model.IsCompiledSuccessfully)
     {
         <div class="alert alert-danger top-buffer">@Resource.Compile_time_error_occured</div>

--- a/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
+++ b/Open Judge System/Web/OJS.Web/Areas/Contests/Views/Submissions/View.cshtml
@@ -69,17 +69,6 @@
             @Html.HiddenFor(m => m.Id)
             <input type="submit" class="btn btn-sm btn-primary" value=@Resource.Retest />
         }
-        <div class="submission-type-box">
-            <div>
-                <p><strong>Submission Type:</strong> @Model.SubmissionType.Name</p>
-            </div>
-            @if (Model.UserHasAdminPermission)
-            {
-                <div>
-                    <p><strong>Submission Type Name:</strong> @Model.SubmissionType.ExecutionStrategyType</p>
-                </div>
-            }
-        </div>
     }
 </div>
 
@@ -362,14 +351,15 @@ else
     <textarea id="code">@Model.ContentAsString</textarea>
 }
 
-<p class="top-buffer">@AdministrationResource.Created_on: @Model.CreatedOn</p>
-
+<p class="top-buffer"><strong>@AdministrationResource.Created_on:</strong> @Model.CreatedOn</p>
 @if (Model.UserHasAdminPermission)
 {
-    <p>@AdministrationResource.Modified_on: @Model.ModifiedOn</p>
-    <p>@AdministrationResource.Started_execution_on: @Model.StartedExecutionOn</p>
-    <p>@AdministrationResource.Completed_execution_on: @Model.CompletedExecutionOn</p>
+    <p><strong>@AdministrationResource.Modified_on</strong>: @Model.ModifiedOn</p>
+    <p><strong>@AdministrationResource.Started_execution_on</strong>: @Model.StartedExecutionOn</p>
+    <p><strong>@AdministrationResource.Completed_execution_on</strong>: @Model.CompletedExecutionOn</p>
+    <p><strong>Submission Type Name:</strong> @Model.SubmissionType.ExecutionStrategyType</p>
 }
+<p><strong>Submission Type:</strong> @Model.SubmissionType.Name</p>
 
 <script>
     function onTestInputDataSuccess() {

--- a/Open Judge System/Web/OJS.Web/Content/css/Submissions/SubmissionDetails.css
+++ b/Open Judge System/Web/OJS.Web/Content/css/Submissions/SubmissionDetails.css
@@ -1,7 +1,4 @@
 ﻿.submission-type-box {
     margin-top: 2rem;
     margin-bottom:2rem;
-    background:#AAA;
-    color: #FFF;
-    padding: 1rem;
 }

--- a/Open Judge System/Web/OJS.Web/Content/css/Submissions/SubmissionDetails.css
+++ b/Open Judge System/Web/OJS.Web/Content/css/Submissions/SubmissionDetails.css
@@ -1,0 +1,7 @@
+﻿.submission-type-box {
+    margin-top: 2rem;
+    margin-bottom:2rem;
+    background:#AAA;
+    color: #FFF;
+    padding: 1rem;
+}

--- a/Open Judge System/Web/OJS.Web/OJS.Web.csproj
+++ b/Open Judge System/Web/OJS.Web/OJS.Web.csproj
@@ -1984,6 +1984,7 @@
     <Content Include="Content\css\home\index\home.css" />
     <Content Include="Content\css\home\search\search-results.css" />
     <Content Include="Content\css\statistics\index\statistics.css" />
+    <Content Include="Content\css\Submissions\SubmissionDetails.css" />
     <Content Include="Content\docs.css" />
     <Content Include="Content\fonts\glyphicons-halflings-regular.svg" />
     <Content Include="Content\KendoUI\Black\editor.png" />


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/945

Added SubmissionType name in the Submission details view.
If user is admin, also the Id of the SubmissionType is displayed.

Execution comment moved after the temp messages.