### PR TITLE
Clear test runs when retest submission

### DIFF
--- a/Services/Administration/OJS.Services.Administration.Business/Implementations/ParticipantScoresBusinessService.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Implementations/ParticipantScoresBusinessService.cs
@@ -34,7 +34,7 @@ public class ParticipantScoresBusinessService : IParticipantScoresBusinessServic
         if (submission != null)
         {
             await this.participantScoresData.ResetBySubmission(submission);
-            await this.testRunsDataService.DeleteByProblem(problemId);
+            await this.testRunsDataService.DeleteBySubmission(submission.Id);
         }
         else
         {

--- a/Services/Administration/OJS.Services.Administration.Business/Implementations/ParticipantScoresBusinessService.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Implementations/ParticipantScoresBusinessService.cs
@@ -13,18 +13,15 @@ public class ParticipantScoresBusinessService : IParticipantScoresBusinessServic
     private readonly IParticipantScoresDataService participantScoresData;
     private readonly IParticipantsDataService participantsData;
     private readonly ISubmissionsDataService submissionsData;
-    private readonly ITestRunsDataService testRunsDataService;
 
     public ParticipantScoresBusinessService(
         IParticipantScoresDataService participantScoresData,
         IParticipantsDataService participantsData,
-        ISubmissionsDataService submissionsData,
-        ITestRunsDataService testRunsDataService)
+        ISubmissionsDataService submissionsData)
     {
         this.participantScoresData = participantScoresData;
         this.participantsData = participantsData;
         this.submissionsData = submissionsData;
-        this.testRunsDataService = testRunsDataService;
     }
 
     public async Task RecalculateForParticipantByProblem(int participantId, int problemId)
@@ -34,7 +31,6 @@ public class ParticipantScoresBusinessService : IParticipantScoresBusinessServic
         if (submission != null)
         {
             await this.participantScoresData.ResetBySubmission(submission);
-            await this.testRunsDataService.DeleteBySubmission(submission.Id);
         }
         else
         {

--- a/Services/Administration/OJS.Services.Administration.Business/Implementations/ParticipantScoresBusinessService.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Implementations/ParticipantScoresBusinessService.cs
@@ -13,15 +13,18 @@ public class ParticipantScoresBusinessService : IParticipantScoresBusinessServic
     private readonly IParticipantScoresDataService participantScoresData;
     private readonly IParticipantsDataService participantsData;
     private readonly ISubmissionsDataService submissionsData;
+    private readonly ITestRunsDataService testRunsDataService;
 
     public ParticipantScoresBusinessService(
         IParticipantScoresDataService participantScoresData,
         IParticipantsDataService participantsData,
-        ISubmissionsDataService submissionsData)
+        ISubmissionsDataService submissionsData,
+        ITestRunsDataService testRunsDataService)
     {
         this.participantScoresData = participantScoresData;
         this.participantsData = participantsData;
         this.submissionsData = submissionsData;
+        this.testRunsDataService = testRunsDataService;
     }
 
     public async Task RecalculateForParticipantByProblem(int participantId, int problemId)
@@ -31,6 +34,7 @@ public class ParticipantScoresBusinessService : IParticipantScoresBusinessServic
         if (submission != null)
         {
             await this.participantScoresData.ResetBySubmission(submission);
+            await this.testRunsDataService.DeleteByProblem(problemId);
         }
         else
         {

--- a/Services/Administration/OJS.Services.Administration.Business/Implementations/SubmissionsBusinessService.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Implementations/SubmissionsBusinessService.cs
@@ -162,7 +162,6 @@ namespace OJS.Services.Administration.Business.Implementations
             {
                 submission.Processed = false;
                 submission.ModifiedOn = this.dates.GetUtcNow();
-
                 var submissionIsBestSubmission = await this.IsBestSubmission(
                     submissionProblemId,
                     submissionParticipantId,

--- a/Services/Administration/OJS.Services.Administration.Business/Implementations/SubmissionsBusinessService.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Implementations/SubmissionsBusinessService.cs
@@ -162,6 +162,7 @@ namespace OJS.Services.Administration.Business.Implementations
             {
                 submission.Processed = false;
                 submission.ModifiedOn = this.dates.GetUtcNow();
+
                 var submissionIsBestSubmission = await this.IsBestSubmission(
                     submissionProblemId,
                     submissionParticipantId,

--- a/Services/Administration/OJS.Services.Administration.Business/Implementations/SubmissionsBusinessService.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Implementations/SubmissionsBusinessService.cs
@@ -29,6 +29,7 @@ namespace OJS.Services.Administration.Business.Implementations
         private readonly ISubmissionsCommonBusinessService submissionsCommonBusinessService;
         private readonly ITransactionsProvider transactions;
         private readonly IDatesService dates;
+        private readonly ITestRunsDataService testRunsDataService;
 
         public SubmissionsBusinessService(
             ISubmissionsDataService submissionsData,
@@ -38,7 +39,8 @@ namespace OJS.Services.Administration.Business.Implementations
             IParticipantScoresBusinessService participantScoresBusinessService,
             ISubmissionPublisherService submissionPublisherService,
             IDatesService dates,
-            ISubmissionsCommonBusinessService submissionsCommonBusinessService)
+            ISubmissionsCommonBusinessService submissionsCommonBusinessService,
+            ITestRunsDataService testRunsDataService)
         {
             this.submissionsData = submissionsData;
             // this.archivedSubmissionsData = archivedSubmissionsData;
@@ -48,6 +50,7 @@ namespace OJS.Services.Administration.Business.Implementations
             this.participantScoresBusinessService = participantScoresBusinessService;
             this.dates = dates;
             this.submissionsCommonBusinessService = submissionsCommonBusinessService;
+            this.testRunsDataService = testRunsDataService;
         }
 
         public Task<IQueryable<Submission>> GetAllForArchiving()
@@ -176,6 +179,8 @@ namespace OJS.Services.Administration.Business.Implementations
                 }
 
                 var serializedExecutionDetails = submissionServiceModel.ToJson();
+
+                await this.testRunsDataService.DeleteBySubmission(submission.Id);
 
                 await this.submissionsForProcessingDataService.CreateIfNotExists(submission.Id, serializedExecutionDetails);
                 await this.submissionsData.SaveChanges();


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/989

Method from testRunsDataService to delete testRuns imported to ParticipantScoresBusinessService to clear the testRuns when retest.