### PR TITLE
Refactored total score to update on refresh on /Contest page

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/problems/problem-submissions/ProblemSubmissions.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/problems/problem-submissions/ProblemSubmissions.tsx
@@ -35,7 +35,7 @@ const ProblemSubmissions = () => {
         [ loadParticipantScores, loadSubmissions, currentProblem ],
     );
 
-    const handleReloadClick = useCallback(async () => {
+    const handleRefreshClick = useCallback(async () => {
         await reload();
     }, [ reload ]);
 
@@ -97,13 +97,13 @@ const ProblemSubmissions = () => {
                     <Button
                       type={ButtonType.secondary}
                       className={refreshButtonClassName}
-                      onClick={() => handleReloadClick()}
+                      onClick={() => handleRefreshClick()}
                       text="Refresh"
                     />
                 </div>
             </>
         ),
-        [ handleReloadClick, refreshButtonClassName, renderSubmissions, submissionResultsContentClassName ],
+        [ handleRefreshClick, refreshButtonClassName, renderSubmissions, submissionResultsContentClassName ],
     );
 
     const renderPage = useCallback(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/use-current-contest.tsx
@@ -430,12 +430,16 @@ const CurrentContestsProvider = ({ children }: ICurrentContestsProviderProps) =>
                 return;
             }
 
-            setScore(sum(problems.map((p) => isNil(p.points)
+            const currentScore = sum(currentContestParticipantScores.map((p) => isNil(p.points)
                 ? 0
-                : p.points)));
-            setMaxScore(sum(problems.map((p) => p.maximumPoints)));
+                : p.points));
+
+            const currentMaxScore = sum(problems.map((p) => p.maximumPoints));
+
+            setScore(currentScore);
+            setMaxScore(currentMaxScore);
         },
-        [ contest ],
+        [ contest, currentContestParticipantScores ],
     );
 
     useEffect(() => {


### PR DESCRIPTION
Closes: https://github.com/SoftUni-Internal/exam-systems-issues/issues/983#event-10549475151

**Summary of the changes made**:
1. Refactored logic to use currentParticipationScores instead of the data from the contest query
