### PR TITLE
Hide timer between submissions if there is a validation error

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
@@ -47,7 +47,19 @@ const SubmissionBox = () => {
     const { state: { currentProblem } } = useProblems();
     const { allowedSubmissionTypes } = currentProblem || {};
 
-    const showSubmissionLimitTimer = useMemo(() => submitLimit > 0, [ submitLimit ]);
+    const showSubmissionLimitTimer = useMemo(
+        () => {
+            const { id: problemId } = currentProblem || {};
+            if (isNil(problemId)) {
+                return false;
+            }
+
+            const { [problemId.toString()]: error } = problemSubmissionErrors;
+
+            return isNil(error) && submitLimit > 0;
+        },
+        [ submitLimit, currentProblem, problemSubmissionErrors ],
+    );
 
     const handleCodeChanged = useCallback(
         (newValue: string | File) => {

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
@@ -34,6 +34,7 @@ const SubmissionBox = () => {
             selectedSubmissionType,
             problemSubmissionCode,
             problemSubmissionErrors,
+            alertBoxErrorIsClosed,
         },
         actions: {
             submit,
@@ -56,9 +57,9 @@ const SubmissionBox = () => {
 
             const { [problemId.toString()]: error } = problemSubmissionErrors;
 
-            return isNil(error) && submitLimit > 0;
+            return isNil(error) && submitLimit > 0 && !alertBoxErrorIsClosed;
         },
-        [ submitLimit, currentProblem, problemSubmissionErrors ],
+        [ submitLimit, currentProblem, problemSubmissionErrors, alertBoxErrorIsClosed ],
     );
 
     const handleCodeChanged = useCallback(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/submission-box/SubmissionBox.tsx
@@ -142,11 +142,21 @@ const SubmissionBox = () => {
                 return;
             }
 
-            removeProblemSubmissionCode(problemId);
+            const { [problemId.toString()]: error } = problemSubmissionErrors;
 
-            restartSubmissionTimeLimitCountdown();
+            removeProblemSubmissionCode(problemId);
+            if (isNil(error)) {
+                restartSubmissionTimeLimitCountdown();
+            }
         },
-        [ submit, currentProblem, problemSubmissionCode, removeProblemSubmissionCode, restartSubmissionTimeLimitCountdown ],
+        [
+            submit,
+            currentProblem,
+            problemSubmissionCode,
+            removeProblemSubmissionCode,
+            restartSubmissionTimeLimitCountdown,
+            problemSubmissionErrors,
+        ],
     );
 
     const renderSubmissionLimitCountdown = useCallback((remainingTime: ICountdownRemainingType) => {

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/submissions/use-submissions.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/hooks/submissions/use-submissions.tsx
@@ -21,6 +21,7 @@ interface ISubmissionsContext {
         problemSubmissionCode: IDictionary<string | File>;
         selectedSubmissionType: ISubmissionTypeType | null;
         problemSubmissionErrors: IDictionary<IErrorDataType | null>;
+        alertBoxErrorIsClosed: boolean;
     };
     actions: {
         submit: () => Promise<void>;
@@ -36,6 +37,7 @@ const defaultState = {
         problemSubmissionCode: {},
         selectedSubmissionType: null,
         problemSubmissionErrors: {},
+        alertBoxErrorIsClosed: false,
     },
 };
 
@@ -58,6 +60,7 @@ const SubmissionsProvider = ({ children }: ISubmissionsProviderProps) => {
         useState<IDictionary<string | File>>(defaultState.state.problemSubmissionCode);
     const [ problemSubmissionErrors, setProblemSubmissionErrors ] =
         useState<IDictionary<IErrorDataType | null>>(defaultState.state.problemSubmissionErrors);
+    const [ alertBoxErrorIsClosed, setAlertBoxErrorIsClosed ] = useState<boolean>(defaultState.state.alertBoxErrorIsClosed);
 
     const { state: { currentProblem } } = useProblems();
     const { actions: { loadSubmissions } } = useProblemSubmissions();
@@ -166,6 +169,7 @@ const SubmissionsProvider = ({ children }: ISubmissionsProviderProps) => {
             }
 
             setIsLoading(false);
+            setAlertBoxErrorIsClosed(false);
             resetProblemSubmissionError();
         },
         [
@@ -244,6 +248,7 @@ const SubmissionsProvider = ({ children }: ISubmissionsProviderProps) => {
                 ...problemSubmissionErrors,
                 [problemId]: null,
             });
+            setAlertBoxErrorIsClosed(true);
         },
         [ problemSubmissionErrors ],
     );
@@ -301,6 +306,7 @@ const SubmissionsProvider = ({ children }: ISubmissionsProviderProps) => {
                 selectedSubmissionType,
                 problemSubmissionErrors,
                 isLoading,
+                alertBoxErrorIsClosed,
             },
             actions: {
                 updateSubmissionCode,
@@ -320,6 +326,7 @@ const SubmissionsProvider = ({ children }: ISubmissionsProviderProps) => {
             closeErrorMessage,
             problemSubmissionErrors,
             isLoading,
+            alertBoxErrorIsClosed,
         ],
     );
 


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/920

Linked pull requests from another repos (if any):

**Summary of the changes made**:
1.  Add a check for validation error when calculating whether to show the timer between submissions
