### PR TITLE
Update page titles only if data arrived

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/submissions/details/SubmissionDetails.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/submissions/details/SubmissionDetails.tsx
@@ -107,9 +107,12 @@ const SubmissionDetails = () => {
 
     useEffect(
         () => {
-            setPageTitle(`Submission №${currentSubmission?.id}`);
+            if (currentSubmission) {
+                setPageTitle(`Submission №${currentSubmission?.id}`);
+            }
         },
-        [ setPageTitle, currentSubmission ],
+        // eslint-disable-next-line
+        [ currentSubmission ],
     );
 
     const problemNameHeadingText = useMemo(

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contest/ContestDetailsPage.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contest/ContestDetailsPage.tsx
@@ -47,16 +47,14 @@ const ContestDetailsPage = () => {
     const { actions: { setPageTitle } } = usePageTitles();
     const navigate = useNavigate();
 
-    const contestTitle = useMemo(
-        () => `${contestDetails?.name}`,
-        [ contestDetails?.name ],
-    );
-
     useEffect(
         () => {
-            setPageTitle(contestTitle);
+            if (contestDetails) {
+                setPageTitle(contestDetails?.name);
+            }
         },
-        [ contestTitle, setPageTitle ],
+        // eslint-disable-next-line
+        [ contestDetails ],
     );
 
     const { contestId, participationType } = params;


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/935

Removed unnecessary dependencies and updates page title only when required.
useMemo is not needed to set the page title.
