### PR TITLE
Return compete and practice participants from backend for contest details page

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/common/types.ts
@@ -88,8 +88,8 @@ interface IContestDetailsResponseType {
     canBePracticed: boolean;
     isAdminOrLecturerInContest: boolean;
     allowedSubmissionTypes: IContestDetailsSubmissionType[];
-    totalContestParticipantsCount: number;
-    participantsCountByContestType: number;
+    competeParticipantsCount: number;
+    practiceParticipantsCount: number;
 }
 
 interface IContestType {

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contest/ContestDetailsPage.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contest/ContestDetailsPage.tsx
@@ -71,13 +71,6 @@ const ContestDetailsPage = () => {
         [ participationType ],
     );
 
-    const participantsCountByContestType = useMemo(
-        () => isOfficial
-            ? `Compete participants: ${contestDetails?.participantsCountByContestType}`
-            : `Practice participants: ${contestDetails?.participantsCountByContestType}`,
-        [ isOfficial, contestDetails?.participantsCountByContestType ],
-    );
-
     const {
         isAccessible: canAccessCompeteButton,
         isAccessibleForAdminOrLecturerInContest: competableOnlyForAdminAndLecturers,
@@ -300,10 +293,12 @@ const ContestDetailsPage = () => {
                             <div>
                                 Contest participants:
                                 {' '}
-                                {contestDetails?.totalContestParticipantsCount}
+                                {contestDetails?.competeParticipantsCount}
                             </div>
                             <div>
-                                {participantsCountByContestType}
+                                Practice participants:
+                                {' '}
+                                {contestDetails?.practiceParticipantsCount}
                             </div>
                         </div>
                         {renderTasksList(problems)}
@@ -314,7 +309,7 @@ const ContestDetailsPage = () => {
                 </div>
             );
         },
-        [ renderTasksList, contestDetails, renderContestButtons, renderAllowedSubmissionTypes, participantsCountByContestType ],
+        [ renderTasksList, contestDetails, renderContestButtons, renderAllowedSubmissionTypes ],
     );
 
     const renderErrorHeading = useCallback(

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/ContestsBusinessService.cs
@@ -119,11 +119,8 @@ namespace OJS.Services.Ui.Business.Implementations
                 .Select(x => new ContestDetailsSubmissionTypeServiceModel { Id = x.SubmissionTypeId, Name = x.SubmissionType.Name })
                 .ToList();
 
-            var competeContestParticipantsCount = await this.contestParticipantsCacheService.GetCompeteContestParticipantsCount(id);
-            var practiceContestParticipantsCount = await this.contestParticipantsCacheService.GetPracticeContestParticipantsCount(id);
-
-            contestDetailsServiceModel.ParticipantsCountByContestType = contest.CanBeCompeted ? competeContestParticipantsCount : practiceContestParticipantsCount;
-            contestDetailsServiceModel.TotalContestParticipantsCount = competeContestParticipantsCount + practiceContestParticipantsCount;
+            contestDetailsServiceModel.CompeteParticipantsCount = await this.contestParticipantsCacheService.GetCompeteContestParticipantsCount(id);
+            contestDetailsServiceModel.PracticeParticipantsCount = await this.contestParticipantsCacheService.GetPracticeContestParticipantsCount(id);
 
             return contestDetailsServiceModel;
         }

--- a/Services/UI/OJS.Services.Ui.Models/Contests/ContestDetailsServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Contests/ContestDetailsServiceModel.cs
@@ -25,9 +25,9 @@ public class ContestDetailsServiceModel : IMapExplicitly
 
     public bool IsAdminOrLecturerInContest { get; set; }
 
-    public int TotalContestParticipantsCount { get; set; }
+    public int CompeteParticipantsCount { get; set; }
 
-    public int ParticipantsCountByContestType { get; set; }
+    public int PracticeParticipantsCount { get; set; }
 
     public ICollection<ContestDetailsSubmissionTypeServiceModel> AllowedSubmissionTypes { get; set; } =
         new HashSet<ContestDetailsSubmissionTypeServiceModel>();
@@ -46,6 +46,6 @@ public class ContestDetailsServiceModel : IMapExplicitly
             .ForMember(d => d.IsAdminOrLecturerInContest, opt => opt.Ignore())
             .ForMember(d => d.CanViewResults, opt => opt.Ignore())
             .ForMember(d => d.AllowedSubmissionTypes, opt => opt.Ignore())
-            .ForMember(d => d.TotalContestParticipantsCount, opt => opt.Ignore())
-            .ForMember(d => d.ParticipantsCountByContestType, opt => opt.Ignore());
+            .ForMember(d => d.CompeteParticipantsCount, opt => opt.Ignore())
+            .ForMember(d => d.PracticeParticipantsCount, opt => opt.Ignore());
 }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/958

Linked pull requests from another repos (if any):

**Summary of the changes made**:
1. Return a separate count for practice and compete participants from backend to display on contest details page
