### PR TITLE
Fix Started and Completed Execution On

### DIFF
--- a/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
+++ b/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
@@ -94,6 +94,8 @@
             this.submission.ProcessingComment = submissionModel.ProcessingComment;
             this.submission.ExecutionComment = $"{ex.Message} {ex.InnerException} \n" + $"{ex.StackTrace}";
             this.submission.ExceptionType = submissionModel.ExceptionType;
+            this.submission.StartedExecutionOn = submissionModel.StartedExecutionOn;
+            this.submission.CompletedExecutionOn = submissionModel.CompletedExecutionOn;
 
             this.UpdateResults();
         }

--- a/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
+++ b/Open Judge System/LocalWorker/OJS.LocalWorker/OjsSubmissionProcessingStrategy.cs
@@ -140,6 +140,9 @@
             this.submission.IsCompiledSuccessfully = executionResult.IsCompiledSuccessfully;
             this.submission.CompilerComment = executionResult.CompilerComment;
 
+            this.submission.StartedExecutionOn = executionResult.StartedExecutionOn;
+            this.submission.CompletedExecutionOn = executionResult.CompletedExecutionOn;
+            
             if (!executionResult.IsCompiledSuccessfully)
             {
                 this.UpdateResults();
@@ -163,9 +166,6 @@
                 this.submission.TestRuns.Add(testRun);
             }
 
-            this.submission.StartedExecutionOn = executionResult.StartedExecutionOn;
-            this.submission.CompletedExecutionOn = executionResult.CompletedExecutionOn;
-            
             this.submissionsData.Update(this.submission);
             this.UpdateResults();
         }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/your_issue_number


When there is exception in the worker the OJSubmission will hold the Started and Completed execution On because the execution result or exception are not used.

https://github.com/SoftUni-Internal/judge-worker/pull/153
https://github.com/SoftUni-Internal/interactive/pull/1594