### PR TITLE
Clear Filters button fix in Contests page

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-categories/ContestCategories.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contest-categories/ContestCategories.tsx
@@ -19,6 +19,7 @@ interface IContestCategoriesProps extends IHaveOptionalClassName {
     onCategoryClick: (filter: IFilter) => void;
     defaultSelected: string;
     setStrategyFilters: Dispatch<SetStateAction<IFilter[]>>;
+    shouldReset: boolean;
 }
 
 interface IFilterProps {
@@ -37,6 +38,7 @@ const ContestCategories = ({
     onCategoryClick,
     defaultSelected,
     setStrategyFilters,
+    shouldReset,
 }: IContestCategoriesProps) => {
     const { state: { categories, categoriesFlat } } = useContestCategories();
     const { state: { possibleFilters } } = useContests();
@@ -226,6 +228,15 @@ const ContestCategories = ({
         [ categoriesFlat, currentCategoryId, getCategoryByValue, handleTreeLabelClick ],
     );
 
+    useEffect(() => {
+        console.log('clear category');
+        setOpenedCategoryFilters(defaultState.state.openedCategoryFilters);
+        setOpenedCategoryFilter(defaultState.state.openedCategoryFilter);
+        selectCurrentCategoryId('');
+        setPrevCategoryId('');
+        clearBreadcrumb();
+    }, [ shouldReset, clearBreadcrumb ]);
+
     useEffect(
         () => {
             if (isEmpty(openedCategoryFilters)) {
@@ -261,6 +272,7 @@ const ContestCategories = ({
               defaultSelected={getCategoryById(defaultSelected)}
               defaultExpanded={defaultExpanded}
               treeItemHasTooltip
+              shouldReset={shouldReset}
             />
         </div>
     );

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contests-filters/ContestFilters.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contests-filters/ContestFilters.tsx
@@ -27,13 +27,14 @@ interface IFiltersGroup {
 const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
     const maxFiltersToDisplayCount = 3;
     const { search } = useLocation();
-    const { actions: { clearParams } } = useUrlParams();
+    const { state: { params }, actions: { clearParams } } = useUrlParams();
     const [ selectValue, setSelectValue ] = useState('');
     const [ filtersGroups, setFiltersGroups ] = useState<IFiltersGroup[]>([]);
     const [ defaultSelected, setDefaultSelected ] = useState('');
     const [ filteredStrategyFilters, setFilteredStrategyFilters ] = useState<IFilter[]>([]);
     const [ searchParams ] = useSearchParams();
     const [ isLoaded, setIsLoaded ] = useState(false);
+    const [ shouldResetCategoriesAndBreadcrumbs, setShouldResetCategoriesAndBreadcrumbs ] = useState(false);
 
     const {
         state: { possibleFilters },
@@ -68,6 +69,16 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
     const handleStrategySelect = useCallback((param: IFilter) => {
         toggleParam(param);
     }, [ toggleParam ]);
+
+    const clearFiltersBreadcrumbSortingPagesAndParameters = useCallback(
+        () => {
+            clearParams();
+            setDefaultSelected('');
+            setFilteredStrategyFilters([]);
+            setShouldResetCategoriesAndBreadcrumbs((prev) => !prev);
+        },
+        [ clearParams ],
+    );
 
     const renderFilter = useCallback(
         (fg: IFiltersGroup) => {
@@ -128,6 +139,12 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
         [ filteredStrategyFilters, handleFilterClick, handleStrategySelect, selectValue ],
     );
 
+    useEffect(() => {
+        if (isEmpty(params)) {
+            clearFiltersBreadcrumbSortingPagesAndParameters();
+        }
+    }, [ params, clearFiltersBreadcrumbSortingPagesAndParameters ]);
+
     useEffect(
         () => {
             const plainFilters = possibleFilters.filter(({ type }) => type !== FilterType.Category);
@@ -160,13 +177,6 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
         [ isLoaded, searchParams ],
     );
 
-    const clearFiltersBreadcrumbSortingPagesAndParameters = useCallback(
-        () => {
-            clearParams();
-        },
-        [ clearParams ],
-    );
-
     return (
         <div className={styles.container}>
             <Button
@@ -181,6 +191,7 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
               onCategoryClick={onFilterClick}
               defaultSelected={defaultSelected}
               setStrategyFilters={setFilteredStrategyFilters}
+              shouldReset={shouldResetCategoriesAndBreadcrumbs}
             />
             {/* Commented out because displaying sorting menu to
             the user is no longer a wanted feature

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/trees/Tree.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/guidelines/trees/Tree.tsx
@@ -21,6 +21,7 @@ interface ITreeProps {
     defaultExpanded?: string[];
     itemFunc?: (item: ITreeItemType) => React.ReactElement;
     treeItemHasTooltip?: boolean;
+    shouldReset?: boolean;
 
 }
 
@@ -31,6 +32,7 @@ const Tree = ({
     defaultExpanded = [],
     itemFunc,
     treeItemHasTooltip = false,
+    shouldReset,
 }: ITreeProps) => {
     const [ expandedIds, setExpandedIds ] = useState([] as string[]);
     const [ selectedId, setSelectedId ] = useState('');
@@ -51,7 +53,7 @@ const Tree = ({
             setSelectedId(node.id.toString());
             onSelect(node);
         },
-        [ expandedIds, onSelect ],
+        [ expandedIds, onSelect, setSelectedId ],
     );
 
     const renderTreeItem = useCallback((node: ITreeItemType) => (
@@ -111,6 +113,14 @@ const Tree = ({
             }
         },
         [ defaultExpanded, expandedIds, selectedFromUrl ],
+    );
+
+    useEffect(
+        () => {
+            setExpandedIds([]);
+            setSelectedId('');
+        },
+        [ shouldReset ],
     );
 
     const renderTreeView = useCallback(


### PR DESCRIPTION
Clear Filters button is fixed - clears Breadcrumbs and shrinks expanded categories. 
Clicking on ''Contests'' on the Nav bar was also not working correctly but is also fixed.

Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/971

**Summary of the changes made**:
1. Extending method handling pressing of Clear Filters button
2. Adding a state variable in ContestFilters.tsx to pass to children components - shouldResetCategoriesAndBreadcrumbs
3. Adding it as a dependency in useEffects to reset children's state related to filters and categories
4. Adding useEffect in ContestFilters with dependency to params - class method for clearing filters when page is being refreshed and there are no url params
