### PR TITLE
Add started and completed execution on when there is compile time error

### DIFF
--- a/PubSub/OJS.PubSub.Worker.Models/Submissions/ProcessedSubmissionPubSubModel.cs
+++ b/PubSub/OJS.PubSub.Worker.Models/Submissions/ProcessedSubmissionPubSubModel.cs
@@ -20,6 +20,10 @@ public class ProcessedSubmissionPubSubModel : IMapExplicitly
 
     public ExecutionResultServiceModel? ExecutionResult { get; set; }
 
+    public DateTime? StartedExecutionOn { get; set; }
+
+    public DateTime? CompletedExecutionOn { get; set; }
+
     public void SetExecutionResult(ExecutionResultServiceModel executionResultModel)
     {
         this.ExecutionResult = executionResultModel;
@@ -30,6 +34,12 @@ public class ProcessedSubmissionPubSubModel : IMapExplicitly
     {
         this.Exception = new ExceptionModel(exception, includeStackTrace);
         this.ExecutionResult = null;
+    }
+
+    public void SetStartedAndCompletedExecutionOn(DateTime startedExecutionOn, DateTime completedExecutionOn)
+    {
+        this.StartedExecutionOn = startedExecutionOn;
+        this.CompletedExecutionOn = completedExecutionOn;
     }
 
     public void RegisterMappings(IProfileExpression configuration)

--- a/Servers/Worker/OJS.Servers.Worker.Models/ExecutionResult/ExecutionResultResponseModel.cs
+++ b/Servers/Worker/OJS.Servers.Worker.Models/ExecutionResult/ExecutionResultResponseModel.cs
@@ -16,8 +16,4 @@ public class ExecutionResultResponseModel : IMapFrom<ExecutionResultServiceModel
     public OutputResultResponseModel? OutputResult { get; set; }
 
     public TaskResultResponseModel? TaskResult { get; set; }
-
-    public DateTime? StartedExecutionOn { get; set; }
-
-    public DateTime? CompletedExecutionOn { get; set; }
 }

--- a/Servers/Worker/OJS.Servers.Worker.Models/ExecutionResult/FullExecutionResultResponseModel.cs
+++ b/Servers/Worker/OJS.Servers.Worker.Models/ExecutionResult/FullExecutionResultResponseModel.cs
@@ -9,6 +9,10 @@ public class FullExecutionResultResponseModel
 
     public ExecutionResultResponseModel? ExecutionResult { get; set; }
 
+    public DateTime? StartedExecutionOn { get; set; }
+
+    public DateTime? CompletedExecutionOn { get; set; }
+
     public void SetExecutionResult(ExecutionResultResponseModel executionResult)
     {
         this.ExecutionResult = executionResult;
@@ -19,5 +23,11 @@ public class FullExecutionResultResponseModel
     {
         this.Exception = new ExceptionModel(exception, includeStackTrace);
         this.ExecutionResult = null;
+    }
+
+    public void SetStartedAndCompletedExecutionOn(DateTime startedExecutionOn, DateTime completedExecutionOn)
+    {
+        this.StartedExecutionOn = startedExecutionOn;
+        this.CompletedExecutionOn = completedExecutionOn;
     }
 }

--- a/Servers/Worker/OJS.Servers.Worker/Consumers/SubmissionsForProcessingConsumer.cs
+++ b/Servers/Worker/OJS.Servers.Worker/Consumers/SubmissionsForProcessingConsumer.cs
@@ -30,6 +30,7 @@ public class SubmissionsForProcessingConsumer : IConsumer<SubmissionForProcessin
         var submission = message.Map<SubmissionServiceModel>();
 
         var result = new ProcessedSubmissionPubSubModel(message.Id);
+        var startedExecutionOn = DateTime.UtcNow;
 
         try
         {
@@ -40,6 +41,10 @@ public class SubmissionsForProcessingConsumer : IConsumer<SubmissionForProcessin
         catch (Exception ex)
         {
             result.SetException(ex, true);
+        }
+        finally
+        {
+            result.SetStartedAndCompletedExecutionOn(startedExecutionOn, completedExecutionOn: DateTime.UtcNow);
         }
 
         return this.publisher.Publish(result);

--- a/Servers/Worker/OJS.Servers.Worker/Controllers/Api/SubmissionsController.cs
+++ b/Servers/Worker/OJS.Servers.Worker/Controllers/Api/SubmissionsController.cs
@@ -64,7 +64,7 @@ public class SubmissionsController : BaseApiController
         bool withStackTrace)
     {
         var result = new FullExecutionResultResponseModel();
-
+        var startedExecutionTime = DateTime.UtcNow;
         try
         {
             var executionResult = this.submissionsBusiness.ExecuteSubmission(submission);
@@ -80,6 +80,10 @@ public class SubmissionsController : BaseApiController
         catch (Exception ex)
         {
             result.SetException(ex, withStackTrace);
+        }
+        finally
+        {
+            result.SetStartedAndCompletedExecutionOn(startedExecutionTime, completedExecutionOn: DateTime.UtcNow);
         }
 
         return await Task.FromResult(result);

--- a/Services/Common/OJS.Services.Common.Models/Submissions/ExecutionResultServiceModel.cs
+++ b/Services/Common/OJS.Services.Common.Models/Submissions/ExecutionResultServiceModel.cs
@@ -18,10 +18,6 @@
 
         public OutputResult? OutputResult { get; set; }
 
-        public DateTime? StartedExecutionOn { get; set; }
-
-        public DateTime? CompletedExecutionOn { get; set; }
-
         public void RegisterMappings(IProfileExpression configuration)
             => configuration
                 .CreateMap(typeof(ExecutionResult<TestResult>), typeof(ExecutionResultServiceModel))

--- a/Services/Common/OJS.Services.Common.Models/Submissions/SubmissionExecutionResult.cs
+++ b/Services/Common/OJS.Services.Common.Models/Submissions/SubmissionExecutionResult.cs
@@ -1,6 +1,7 @@
 ﻿namespace OJS.Services.Common.Models.Submissions
 {
     using OJS.Workers.SubmissionProcessors.Models;
+    using System;
 
     public class SubmissionExecutionResult
     {
@@ -9,5 +10,9 @@
         public ExceptionModel? Exception { get; set; }
 
         public ExecutionResultServiceModel? ExecutionResult { get; set; }
+
+        public DateTime? StartedExecutionOn { get; set; }
+
+        public DateTime? CompletedExecutionOn { get; set; }
     }
 }

--- a/Services/UI/OJS.Services.Ui.Business/Implementations/SubmissionsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Implementations/SubmissionsBusinessService.cs
@@ -480,8 +480,8 @@ public class SubmissionsBusinessService : ISubmissionsBusinessService
                 $"Submission with Id: \"{submissionExecutionResult.SubmissionId}\" not found.");
         }
 
-        submission.StartedExecutionOn = submissionExecutionResult.ExecutionResult?.StartedExecutionOn;
-        submission.CompletedExecutionOn = submissionExecutionResult.ExecutionResult?.CompletedExecutionOn;
+        submission.StartedExecutionOn = submissionExecutionResult.StartedExecutionOn;
+        submission.CompletedExecutionOn = submissionExecutionResult.CompletedExecutionOn;
 
         var exception = submissionExecutionResult.Exception;
         var executionResult = submissionExecutionResult.ExecutionResult;

--- a/Services/Worker/OJS.Services.Worker.Business/Implementations/SubmissionsBusinessService.cs
+++ b/Services/Worker/OJS.Services.Worker.Business/Implementations/SubmissionsBusinessService.cs
@@ -48,8 +48,6 @@ public class SubmissionsBusinessService : ISubmissionsBusinessService
 
     public ExecutionResultServiceModel ExecuteSubmission(SubmissionServiceModel submission)
     {
-        submission.StartedExecutionOn = DateTime.UtcNow;
-
         this.submissionsValidation
             .GetValidationResult(submission)
             .VerifyResult();
@@ -157,8 +155,6 @@ public class SubmissionsBusinessService : ISubmissionsBusinessService
 
         var executionResult = this.mapper.Map<ExecutionResultServiceModel>(ojsWorkerExecutionResult);
 
-        executionResult.StartedExecutionOn = submission.StartedExecutionOn;
-
         var taskMaxPoints = submission.TestsExecutionDetails?.MaxPoints ?? TaskDefaultMaxPoints;
 
         if (executionResult.TaskResult == null)
@@ -169,8 +165,6 @@ public class SubmissionsBusinessService : ISubmissionsBusinessService
         {
             this.ProcessTaskResult(submission, executionResult, taskMaxPoints);
         }
-
-        executionResult.CompletedExecutionOn = DateTime.UtcNow;
 
         return executionResult;
     }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1013

Linked pull requests from another repos (if any):
[https://github.com/SoftUni-Internal/judge-worker/pull/154]

**Summary of the changes made**:
Started and completed execution on moved from the executionResult to the response full model. Both properties will always present in the model.
