### PR TITLE
Contest strategy filter dropdown bug

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contests-filters/ContestFilters.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/contests/contests-filters/ContestFilters.tsx
@@ -84,9 +84,18 @@ const ContestFilters = ({ onFilterClick }: IContestFiltersProps) => {
         (fg: IFiltersGroup) => {
             const { type, filters: groupFilters } = fg;
 
+            const currentSelectedFilter =
+                groupFilters.find(({ value }) => value.toString() === selectValue);
+
+            // Array is passed to the dropdown for strategy selection
+            // If there are no filtered strategies we pass all group filters
+            // If the currently selected filter is not in the filteredStrategyFilters
+            // it has to be added to the array in order for it to be displayed in the dropdown
             const strategyFilters = isEmpty(filteredStrategyFilters)
                 ? groupFilters
-                : filteredStrategyFilters;
+                : currentSelectedFilter && !filteredStrategyFilters.includes(currentSelectedFilter)
+                    ? [ ...filteredStrategyFilters, currentSelectedFilter ]
+                    : [ ...filteredStrategyFilters ];
 
             if (type === FilterType.Strategy) {
                 return (

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contests/ContestsPage.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/pages/contests/ContestsPage.tsx
@@ -44,8 +44,10 @@ const ContestsPage = () => {
     const { state: { breadcrumbItems } } = useCategoriesBreadcrumbs();
     const { state: { categoriesFlat }, actions: { load: loadCategories } } = useContestCategories();
     const { state: params, actions: { clearParams } } = useUrlParams();
-    const { state: { strategies } } = useContestStrategyFilters();
-    const { actions: { load: loadStrategies } } = useContestStrategyFilters();
+    const {
+        state: { strategies },
+        actions: { load: loadStrategies },
+    } = useContestStrategyFilters();
     const [ showAlert, setShowAlert ] = useState<boolean>(false);
 
     useEffect(


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1059

**Summary of the changes made**:
1. Refactoring renderFilter method in ContestFilters - If the currently selected strategy is not part of the selected category's strateies the currently selected filter has to be added explicitly to the filteredStrategyFilters array so that MUI component doesn't throw error and displays the correct value

