### PR TITLE
Updated GetUserSubmissionsByProblem endpoint to return unified data

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/Controllers/Api/SubmissionsController.cs
+++ b/Servers/UI/OJS.Servers.Ui/Controllers/Api/SubmissionsController.cs
@@ -87,19 +87,20 @@ public class SubmissionsController : BaseApiController
     /// <summary>
     /// Gets a subset of submissions by specific problem.
     /// </summary>
-    /// <param name="id">The id of the problem.</param>
+    /// <param name="problemId">The id of the problem.</param>
     /// <param name="isOfficial">Should the submissions be only from compete mode.</param>
     /// <param name="page">Current submissions page.</param>
     /// <returns>A collection of submissions for a specific problem.</returns>
-    [HttpGet("{id:int}")]
-    [ProducesResponseType(typeof(PagedResultResponse<SubmissionResultsResponseModel>), Status200OK)]
-    public async Task<IActionResult> GetSubmissionResultsByProblem(
-        int id,
+    [HttpGet("{problemId:int}")]
+    [Authorize]
+    [ProducesResponseType(typeof(PagedResultResponse<PublicSubmissionsResponseModel>), Status200OK)]
+    public async Task<IActionResult> GetUserSubmissionsByProblem(
+        int problemId,
         [FromQuery] bool isOfficial,
         [FromQuery] int page)
         => await this.submissionsBusiness
-            .GetSubmissionResultsByProblem(id, isOfficial, page)
-            .Map<PagedResultResponse<SubmissionResultsResponseModel>>()
+            .GetUserSubmissionsByProblem(problemId, isOfficial, page)
+            .Map<PagedResultResponse<PublicSubmissionsServiceModel>>()
             .ToOkResult();
 
     /// <summary>

--- a/Services/UI/OJS.Services.Ui.Business/ISubmissionsBusinessService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/ISubmissionsBusinessService.cs
@@ -4,6 +4,7 @@
     using OJS.Data.Models.Submissions;
     using OJS.Services.Common.Models.Submissions;
     using OJS.Services.Ui.Models.Submissions;
+    using OJS.Services.Ui.Models.Submissions.PublicSubmissions;
     using SoftUni.Common.Models;
     using SoftUni.Services.Infrastructure;
     using System.Linq;
@@ -34,7 +35,7 @@
 
         Task<PagedResult<SubmissionResultsServiceModel>> GetSubmissionResults(int submissionId, int page);
 
-        Task<PagedResult<SubmissionResultsServiceModel>> GetSubmissionResultsByProblem(int problemId, bool isOfficial, int page);
+        Task<PagedResult<PublicSubmissionsServiceModel>> GetUserSubmissionsByProblem(int problemId, bool isOfficial, int page);
 
         Task<int> GetTotalCount();
 

--- a/Services/UI/OJS.Services.Ui.Business/Validations/Implementations/Submissions/ISubmissionResultsValidationService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Validations/Implementations/Submissions/ISubmissionResultsValidationService.cs
@@ -2,8 +2,9 @@
 
 using OJS.Services.Common.Models.Users;
 using OJS.Services.Common.Validation;
+using OJS.Services.Ui.Models.Participants;
 using OJS.Services.Ui.Models.Submissions;
 
-public interface ISubmissionResultsValidationService : IValidationService<(UserInfoModel, ProblemForSubmissionDetailsServiceModel?, ParticipantSubmissionResultsServiceModel?, bool)>
+public interface ISubmissionResultsValidationService : IValidationService<(UserInfoModel, ProblemForSubmissionDetailsServiceModel?, ParticipantServiceModel?, bool)>
 {
 }

--- a/Services/UI/OJS.Services.Ui.Business/Validations/Implementations/Submissions/SubmissionResultsValidationService.cs
+++ b/Services/UI/OJS.Services.Ui.Business/Validations/Implementations/Submissions/SubmissionResultsValidationService.cs
@@ -3,11 +3,13 @@
 using OJS.Services.Common.Models;
 using OJS.Services.Common.Models.Users;
 using OJS.Services.Ui.Business.Validations.Implementations.Contests;
+using OJS.Services.Ui.Models.Participants;
 using OJS.Services.Ui.Models.Submissions;
 
 public class SubmissionResultsValidationService : ISubmissionResultsValidationService
 {
-    public ValidationResult GetValidationResult((UserInfoModel, ProblemForSubmissionDetailsServiceModel?, ParticipantSubmissionResultsServiceModel?, bool) validationInput)
+    public ValidationResult GetValidationResult(
+        (UserInfoModel, ProblemForSubmissionDetailsServiceModel?, ParticipantServiceModel?, bool) validationInput)
     {
         var (userInfoModel, problem, participant, isOfficial) = validationInput;
 

--- a/Services/UI/OJS.Services.Ui.Data/Implementations/ParticipantsDataService.cs
+++ b/Services/UI/OJS.Services.Ui.Data/Implementations/ParticipantsDataService.cs
@@ -21,7 +21,8 @@ namespace OJS.Services.Ui.Data.Implementations
             int contestId,
             string userId,
             bool isOfficial)
-            => this.GetAllByContestByUserAndIsOfficial(contestId, userId, isOfficial)
+            => this
+                .GetAllByContestByUserAndIsOfficial(contestId, userId, isOfficial)
                 .FirstOrDefaultAsync();
 
         public Task<Participant?> GetWithContestAndSubmissionDetailsByContestByUserAndIsOfficial(int contestId, string userId, bool isOfficial)
@@ -130,7 +131,8 @@ namespace OJS.Services.Ui.Data.Implementations
             int contestId,
             string userId,
             bool isOfficial)
-            => this.GetAllByContestAndUser(contestId, userId)
+            => this
+                .GetAllByContestAndUser(contestId, userId)
                 .Where(p => p.IsOfficial == isOfficial);
     }
 }

--- a/Services/UI/OJS.Services.Ui.Models/Participants/ParticipantServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Participants/ParticipantServiceModel.cs
@@ -6,7 +6,7 @@ using OJS.Data.Models.Participants;
 
 public class ParticipantServiceModel : IMapFrom<Participant>
 {
-    public int? Id { get; set; }
+    public int Id { get; set; }
 
     public DateTime? ParticipationEndTime { get; set; }
 }

--- a/Services/UI/OJS.Services.Ui.Models/Submissions/ParticipantSubmissionResultsServiceModel.cs
+++ b/Services/UI/OJS.Services.Ui.Models/Submissions/ParticipantSubmissionResultsServiceModel.cs
@@ -1,9 +1,0 @@
-namespace OJS.Services.Ui.Models.Submissions;
-
-using OJS.Data.Models.Participants;
-using SoftUni.AutoMapper.Infrastructure.Models;
-
-public class ParticipantSubmissionResultsServiceModel : IMapFrom<Participant>
-{
-    public int Id { get; set; }
-}


### PR DESCRIPTION
Updated endpoint so it uses `SubmissionResultsResponseModel` that is used in other parts of the application

/api/Submissions/GetUserSubmissionsByProblem/{problemId}?isOfficial={isOfficial}&page={page}
