### PR TITLE
Hide sections for lecturers

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/portals/administration/AdministrationPortal.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/portals/administration/AdministrationPortal.tsx
@@ -43,6 +43,7 @@ import AdministrationTestsPage from '../../../pages/administration-new/tests/Adm
 import AdministrationUsersPage from '../../../pages/administration-new/users/AdministrationUsersPage';
 import AdministrationCheckersPage from '../../../pages/checkers/AdministrationCheckersPage';
 import NotFoundPage from '../../../pages/not-found/NotFoundPage';
+import { useAppSelector } from '../../../redux/store';
 import AdministrationContestPage from '../../administration/contests/AdministrationContestPage';
 import AdministrationExamGroupPage from '../../administration/exam-groups/AdministrationExamGroupPage';
 import AdministrationProblemGroup from '../../administration/problem-groups/AdministrationProblemGroup';
@@ -65,71 +66,97 @@ const administrationItems = [
         name: 'Contests',
         icon: <AutoStoriesIcon />,
         path: `${CONTESTS_PATH}`,
+        visibleOnlyForAdmin: false,
     },
     {
         name: 'Contest Categories',
         icon: <BookmarksIcon />,
         path: `${CONTEST_CATEGORIES_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Submissions',
         icon: <PlaylistAddCheckCircleIcon />,
         path: `${SUBMISSIONS_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Submissions For Processing',
         icon: <DataSaverOnIcon />,
         path: `${SUBMISSIONS_FOR_PROCESSING_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Tests',
         icon: <ScienceIcon />,
         path: `${TESTS_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Problems',
         icon: <NotListedLocationIcon />,
         path: `${PROBLEMS_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Problem Groups',
         icon: <TableViewIcon />,
         path: `${PROBLEM_GROUPS_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Problem Resources',
         icon: <GiFiles />,
         path: `${PROBLEM_RESOURCES_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Submission Types',
         icon: <BorderAllIcon />,
         path: `${SUBMISSION_TYPES_PATH}`,
+        visibleOnlyForAdmin: true,
+
     },
     {
         name: 'Checkers',
         icon: <FaCheckDouble />,
         path: `${CHECKERS_PATH}`,
+        visibleOnlyForAdmin: true,
+
     },
     {
         name: 'Participants',
         icon: <MdOutlineRememberMe />,
         path: `${PARTICIPANTS_PATH}`,
+        visibleOnlyForAdmin: false,
+
     },
     {
         name: 'Roles',
         icon: <MdOutlineAirlineStops />,
         path: `${ROLES_PATH}`,
+        visibleOnlyForAdmin: true,
+
     },
     {
         name: 'Users',
         icon: <FaUsers />,
         path: `${USERS_PATH}`,
+        visibleOnlyForAdmin: true,
+
     },
     {
         name: 'Exam Groups',
         icon: <FaLayerGroup />,
         path: `${EXAM_GROUPS_PATH}`,
+        visibleOnlyForAdmin: false,
     },
 ];
 const openedMixin = (theme: Theme): CSSObject => ({
@@ -200,6 +227,8 @@ const AdministrationPortal = () => {
     const [ open, setOpen ] = useState(true);
     const [ locationTitle, setLocationTitle ] = useState('');
 
+    const user = useAppSelector((x) => x.authorization.internalUser);
+
     useEffect(() => {
         const locationPathnameElements = location.pathname.split('/');
         const lastElementOfThePathname = locationPathnameElements[locationPathnameElements.length - 1];
@@ -252,86 +281,107 @@ const AdministrationPortal = () => {
         {
             path: `${CONTESTS_PATH}`,
             Element: AdministrationContestsPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${CONTESTS_PATH}/:id`,
             Element: AdministrationContestPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${CONTEST_CATEGORIES_PATH}`,
             Element: AdministrationContestCategories,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${SUBMISSIONS_PATH}`,
             Element: AdministrationSubmissionsPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${SUBMISSIONS_FOR_PROCESSING_PATH}`,
             Element: AdministrationSubmissionsForProcessingPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${SUBMISSIONS_FOR_PROCESSING_PATH}/:id`,
             Element: AdminSubmissionForProcessingDetails,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${TESTS_PATH}`,
             Element: AdministrationTestsPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${TESTS_PATH}/:id`,
             Element: AdministrationTest,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${PROBLEMS_PATH}`,
             Element: AdministrationProblemsPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${PROBLEMS_PATH}/:id`,
             Element: AdministrationProblem,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${PROBLEM_GROUPS_PATH}`,
             Element: AdministrationProblemGroupsPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${PROBLEM_GROUPS_PATH}/:id`,
             Element: AdministrationProblemGroup,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${PROBLEM_RESOURCES_PATH}`,
             Element: AdministrationProblemResourcesPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${PROBLEM_RESOURCES_PATH}/:id`,
             Element: AdministrationProblemResource,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${SUBMISSION_TYPES_PATH}`,
             Element: AdministrationSubmissionTypesPage,
+            visibleOnlyForAdmin: true,
         },
         {
             path: `${CHECKERS_PATH}`,
             Element: AdministrationCheckersPage,
+            visibleOnlyForAdmin: true,
         },
         {
             path: `${PARTICIPANTS_PATH}`,
             Element: ParticipantsAdministrationPage,
+            visibleOnlyForAdmin: false,
         },
         {
             path: `${ROLES_PATH}`,
             Element: AdministrationRolesPage,
+            visibleOnlyForAdmin: true,
         },
         {
             path: `${ROLES_PATH}/:id`,
             Element: AdministrationRole,
+            visibleOnlyForAdmin: true,
         },
         {
             path: `${USERS_PATH}`,
             Element: AdministrationUsersPage,
+            visibleOnlyForAdmin: true,
         },
         {
             path: `${USERS_PATH}/:id`,
             Element: AdministrationUser,
+            visibleOnlyForAdmin: true,
         },
         {
             path: `${EXAM_GROUPS_PATH}`,
@@ -396,7 +446,7 @@ const AdministrationPortal = () => {
                         <div />
                     </DrawerHeader>
                     <List sx={{ overflow: 'hidden' }}>
-                        {administrationItems.map((item) => (
+                        {administrationItems.map((item) => (user.isAdmin || !item.visibleOnlyForAdmin) && (
                             <Box key={item.path}>
                                 <ListItem key={item.name} disablePadding>
                                     <Link
@@ -427,7 +477,12 @@ const AdministrationPortal = () => {
                 <Box className={styles.main} component="main" sx={{ flexGrow: 1 }}>
                     <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="bg">
                         <Routes>
-                            {adminRoutes.map(({ path, Element }) => <Route key={path} path={path} element={<Element />} />)}
+                            {adminRoutes.map(({ path, Element, visibleOnlyForAdmin }) => {
+                                if (user.isAdmin || !visibleOnlyForAdmin) {
+                                    return <Route key={path} path={path} element={<Element />} />;
+                                }
+                                return null;
+                            })}
                             <Route path="/" element={<Navigate to={`/${NEW_ADMINISTRATION_PATH}/${CONTESTS_PATH}`} replace />} />
                             <Route path="*" element={<NotFoundPage />} />
                         </Routes>

--- a/Services/Administration/OJS.Services.Administration.Data/Implementations/ContestsDataService.cs
+++ b/Services/Administration/OJS.Services.Administration.Data/Implementations/ContestsDataService.cs
@@ -155,6 +155,7 @@ namespace OJS.Services.Administration.Data.Implementations
                     c.Id == id &&
                     c.ExamGroups.Any(eg => eg.UsersInExamGroups.Any(u => u.UserId == userId)));
 
+        // Lecturers can see contests in which they are lecturers or contests that are in a category for which they are lecturers.
         protected override Expression<Func<Contest, bool>> GetUserFilter(UserInfoModel user)
             => contest => user.IsAdmin ||
                 contest.Category!.LecturersInContestCategories.Any(cc => cc.LecturerId == user.Id) ||


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1232

**Summary of the changes made**:
1. Added flag on the FE to determine if the section and route are only for admins.