### PR TITLE
Fix wrong contest category displayed in contest view.

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/contests/contest-edit/ContestEdit.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/contests/contest-edit/ContestEdit.tsx
@@ -119,16 +119,6 @@ const ContestEdit = (props:IContestEditProps) => {
     );
 
     useEffect(() => {
-        if (contestCategories) {
-            setContest((prevState) => ({
-                ...prevState,
-                categoryId: contestCategories[0].id,
-                categoryName: contestCategories[0].name,
-            }));
-        }
-    }, [ contestCategories ]);
-
-    useEffect(() => {
         if (data) {
             setContest(data);
         }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1240

**Summary of the changes made**:
1. UseEffect which always sets contest category to the first one in the array of contest categories removed.
2. 
