### PR TITLE
Rename test enums and show correct value for compete tests.

### DIFF
--- a/Servers/Administration/OJS.Servers.Administration/Controllers/TestsController.cs
+++ b/Servers/Administration/OJS.Servers.Administration/Controllers/TestsController.cs
@@ -290,9 +290,9 @@ public class TestsController : BaseAutoCrudAdminController<Test>
             Type = typeof(TestTypeEnum),
             Options = EnumUtils.GetValuesFrom<TestTypeEnum>().Cast<object>(),
             Value = entity.IsOpenTest
-                ? TestTypeEnum.Compete
+                ? TestTypeEnum.Open
                 : entity.IsTrialTest
-                    ? TestTypeEnum.Practice
+                    ? TestTypeEnum.Trial
                     : TestTypeEnum.Standard,
         };
 
@@ -368,11 +368,11 @@ public class TestsController : BaseAutoCrudAdminController<Test>
         Enum.TryParse<TestTypeEnum>(actionContext.GetFormValue(AdditionalFormFields.Type), out var testType);
         switch (testType)
         {
-            case TestTypeEnum.Practice:
+            case TestTypeEnum.Trial:
                 entity.IsTrialTest = true;
                 entity.IsOpenTest = false;
                 break;
-            case TestTypeEnum.Compete:
+            case TestTypeEnum.Open:
                 entity.IsTrialTest = false;
                 entity.IsOpenTest = true;
                 break;

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/tests/types.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/tests/types.ts
@@ -23,8 +23,8 @@ interface ITestInListData {
 
 enum TestTypes {
     'Standard' = 0,
-    'Practice' = 1,
-    'Compete' = 2,
+    'Trial' = 1,
+    'Open' = 2,
 }
 
 export { TestTypes };

--- a/Services/Administration/OJS.Services.Administration.Business/Tests/TestsBusinessService.cs
+++ b/Services/Administration/OJS.Services.Administration.Business/Tests/TestsBusinessService.cs
@@ -255,11 +255,11 @@ public class TestsBusinessService : AdministrationOperationService<Test, int, Te
         Enum.TryParse<TestTypeEnum>(model.Type, out var testType);
         switch (testType)
         {
-            case TestTypeEnum.Practice:
+            case TestTypeEnum.Trial:
                 entity.IsTrialTest = true;
                 entity.IsOpenTest = false;
                 break;
-            case TestTypeEnum.Compete:
+            case TestTypeEnum.Open:
                 entity.IsTrialTest = false;
                 entity.IsOpenTest = true;
                 break;

--- a/Services/Administration/OJS.Services.Administration.Models/Problems/ProblemInListModel.cs
+++ b/Services/Administration/OJS.Services.Administration.Models/Problems/ProblemInListModel.cs
@@ -49,7 +49,7 @@ public class ProblemInListModel : IMapExplicitly
             .ForMember(x => x.PracticeTestsCount, opt
                 => opt.MapFrom(p => p.Tests.Count(test => test.IsTrialTest)))
             .ForMember(x => x.CompeteTestsCount, opt
-                => opt.MapFrom(p => p.Tests.Count(test => test.IsOpenTest)))
+                => opt.MapFrom(p => p.Tests.Count(test => !test.IsTrialTest)))
             .ForMember(x => x.MaximumPoints, opt
                 => opt.MapFrom(p => p.MaximumPoints))
             .ForMember(x => x.IsDeleted, opt

--- a/Services/Administration/OJS.Services.Administration.Models/Tests/TestAdministrationModel.cs
+++ b/Services/Administration/OJS.Services.Administration.Models/Tests/TestAdministrationModel.cs
@@ -69,8 +69,8 @@ public class TestAdministrationModel : BaseAdministrationModel<int>, IMapExplici
 
     private static string? MapTestType(bool isTrialTest, bool isOpenTest) =>
         isOpenTest
-            ? TestTypeEnum.Compete.ToString()
+            ? TestTypeEnum.Open.ToString()
             : isTrialTest
-                ? TestTypeEnum.Practice.ToString()
+                ? TestTypeEnum.Trial.ToString()
                 : TestTypeEnum.Standard.ToString();
 }

--- a/Services/Administration/OJS.Services.Administration.Models/Tests/TestTypeEnum.cs
+++ b/Services/Administration/OJS.Services.Administration.Models/Tests/TestTypeEnum.cs
@@ -3,6 +3,6 @@
 public enum TestTypeEnum
 {
     Standard = 0,
-    Practice = 1,
-    Compete = 2,
+    Trial = 1,
+    Open = 2,
 }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1260#event-12591009003

**Summary of the changes made**:
1. Test enums renamed to match legacy.
2.  Fix compete tests count in maping for ProblemsInListModel
