### PR TITLE
Fix secondary request for getting problem

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/problems/AdministrationProblem.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/problems/AdministrationProblem.tsx
@@ -4,7 +4,6 @@ import { useLocation } from 'react-router';
 import { useGetContestActivityQuery } from '../../../redux/services/admin/contestsAdminService';
 import { getAndSetExceptionMessage } from '../../../utils/messages-utils';
 import { renderErrorMessagesAlert } from '../../../utils/render-utils';
-import SpinningLoader from '../../guidelines/spinning-loader/SpinningLoader';
 import TabsInView from '../common/tabs/TabsInView';
 
 import ProblemForm from './problem-form/ProblemForm';
@@ -24,7 +23,7 @@ const AdministrationProblem = () => {
     const [ contestId, setContestId ] = useState<number>(0);
     const [ skipGettingContestActivity, setSkipGettingContestActivity ] = useState<boolean>(true);
 
-    const { refetch, data: activityData, error: activityError, isLoading: isGettingActivity, isFetching: isFetchingActivity } =
+    const { refetch, data: activityData, error: activityError } =
     useGetContestActivityQuery(Number(contestId), { skip: skipGettingContestActivity });
 
     const onTabChange = (event: React.SyntheticEvent, newValue: PROBLEM_LISTED_DATA) => {

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/problems/AdministrationProblem.tsx
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/components/administration/problems/AdministrationProblem.tsx
@@ -68,9 +68,6 @@ const AdministrationProblem = () => {
         />
     );
 
-    if (isGettingActivity || isFetchingActivity) {
-        return <SpinningLoader />;
-    }
     return (
         <>
             {renderErrorMessagesAlert(errorMessages)}


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1268

**Summary of the changes made**:
1. Loading for contest activity removed because when the requests arrives it causes ProblemForm to re-render and therefore send secondary request for getting problem
2. 
