### PR TITLE
Fixed JS Apps strategy separate tests to add proper test result Id

### DIFF
--- a/Services/Common/OJS.Workers/OJS.Workers.ExecutionStrategies/RunSpaAndExecuteMochaTestsExecutionStrategySeparateTests.cs
+++ b/Services/Common/OJS.Workers/OJS.Workers.ExecutionStrategies/RunSpaAndExecuteMochaTestsExecutionStrategySeparateTests.cs
@@ -435,7 +435,6 @@ finally:
                         ResultType = TestRunResultType.WrongAnswer,
                         CheckerDetails = new CheckerDetails
                         {
-                            ExpectedOutputFragment = t.Output,
                             UserOutputFragment = receivedOutput,
                         },
                     })

--- a/Services/Common/OJS.Workers/OJS.Workers.ExecutionStrategies/RunSpaAndExecuteMochaTestsExecutionStrategySeparateTests.cs
+++ b/Services/Common/OJS.Workers/OJS.Workers.ExecutionStrategies/RunSpaAndExecuteMochaTestsExecutionStrategySeparateTests.cs
@@ -427,19 +427,19 @@ finally:
             JsonExecutionResult mochaResult = JsonExecutionResult.Parse(PreproccessReceivedExecutionOutput(receivedOutput));
             if (mochaResult.TotalTests == 0)
             {
-                return new List<TestResult>
-                {
-                    new TestResult
+                return tests
+                    .Select(t => new TestResult
                     {
-                        Id = 0,
-                        IsTrialTest = false,
+                        Id = t.Id,
+                        IsTrialTest = t.IsTrialTest,
                         ResultType = TestRunResultType.WrongAnswer,
                         CheckerDetails = new CheckerDetails
                         {
+                            ExpectedOutputFragment = t.Output,
                             UserOutputFragment = receivedOutput,
                         },
-                    },
-                };
+                    })
+                    .ToList();
             }
 
             var titlesToTestsMapping = MapTitlesToTestId(


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1293

**Summary of the changes made**:
1. TestId is mapped correctly in JS Apps separate tests strategy
2. ExpectedOutput fragment is returned
3. IsTrial tests is mapped from actual test
