### PR TITLE
Fix missing env for running in docker and added node symlink

### DIFF
--- a/Docker/envs/common.env
+++ b/Docker/envs/common.env
@@ -1,2 +1,3 @@
 # Environment Configuration
 ASPNETCORE_URLS=http://*:80
+DOTNET_RUNNING_IN_CONTAINER=true

--- a/Docker/worker_base/js/setup_node.sh
+++ b/Docker/worker_base/js/setup_node.sh
@@ -7,3 +7,5 @@ cd ./js-run-spa-in-docker-and-execute-mocha-tests && npm install
 
 cd ../../v12 && nvm use 12.22.12 && npm install
 cd ./js-run-spa-in-docker-and-execute-mocha-tests && npm install
+
+ln -sf "$(which node)" /usr/bin/node


### PR DESCRIPTION
- Fixed old strategy does not work because of missing env variable when ran locally
- New strategy needs symlink to find node 