### PR TITLE
The remaining time is now correctly displayed in the contest's card.

### DIFF
--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -24,7 +24,6 @@ const convertTimeIntervalToHoursMinutesAndSeconds =
 
 const calculateTimeUntil = (date: Date, unit: unitOfTime.Diff = 'milliseconds'):
     Duration => moment.duration(moment(date)
-    .utc(true)
     .local()
     .diff(moment()
         .local()), unit);

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -24,6 +24,7 @@ const convertTimeIntervalToHoursMinutesAndSeconds =
 
 const calculateTimeUntil = (date: Date, unit: unitOfTime.Diff = 'milliseconds'):
     Duration => moment.duration(moment(date)
+    .utc(true)
     .local()
     .diff(moment()
         .local()), unit);

--- a/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
+++ b/Servers/UI/OJS.Servers.Ui/ClientApp/src/utils/dates.ts
@@ -17,7 +17,8 @@ const dateTimeFormatWithSpacing = 'D MMM YY, HH:mm';
 
 const calculateTimeBetweenTwoDates = (startDate: Date, endDate: Date) => moment(startDate).diff(moment(endDate), 'second');
 
-const calculatedTimeFormatted = (duration: Duration) => `${duration.days()} d, ${duration.hours()} h, ${duration.minutes()} m`;
+const calculatedTimeFormatted =
+    (duration: Duration) => `${Math.floor(duration.asDays())} d, ${duration.hours()} h, ${duration.minutes()} m`;
 
 const convertTimeIntervalToHoursMinutesAndSeconds =
     (duration: Duration) => `${Math.floor(duration.asHours())}:${duration.minutes()}:${duration.seconds()}`;


### PR DESCRIPTION
The function incorrectly converts the 'date' variable to UTC, despite it already being in UTC format. This leads to incorrect calculations. The 'date' variable does not explicitly specify its timezone (e.g., ```2024-06-20T21:00:16```), so calling ```.utc()``` on it shifts the time by -3 hours, resulting in an incorrect value (e.g., ```2024-06-20T18:00:16```). This change removes the unnecessary UTC conversion, ensuring accurate calculations.

Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1308