### PR TITLE
Added check for Processing state before marking submission as Enqueued

### DIFF
--- a/Servers/Worker/OJS.Servers.Worker/Consumers/SubmissionsForProcessingConsumer.cs
+++ b/Servers/Worker/OJS.Servers.Worker/Consumers/SubmissionsForProcessingConsumer.cs
@@ -49,12 +49,12 @@ public class SubmissionsForProcessingConsumer : IConsumer<SubmissionForProcessin
             ProcessingStartedAt = startedExecutionOn,
         };
 
+        await this.publisher.Publish(submissionStartedProcessingPubSubModel);
+
         var result = new ProcessedSubmissionPubSubModel(context.Message.Id)
         {
             WorkerName = workerName,
         };
-
-        await this.publisher.Publish(submissionStartedProcessingPubSubModel);
 
         try
         {

--- a/Services/Common/OJS.Services.Common/Implementations/SubmissionsCommonBusinessService.cs
+++ b/Services/Common/OJS.Services.Common/Implementations/SubmissionsCommonBusinessService.cs
@@ -92,16 +92,19 @@ public class SubmissionsCommonBusinessService : ISubmissionsCommonBusinessServic
         {
             case SubmissionProcessingState.Processed:
                 // Race condition can occur and the submission can already be marked as processed when we reach this point,
-                // but it is not a problem, as the submission is processed and there is no need to touch it anymore.
+                // but it is not a problem, as the submission is already picked up and there is no need to touch it anymore.
+                // We just log the event and update the enqueued time. The worker will do the rest.
                 this.logger.LogSubmissionAlreadyProcessed(submission.Id);
+                await this.UpdateEnqueuedTime(freshSubmissionForProcessing, enqueuedAt);
                 break;
             case SubmissionProcessingState.Processing:
                 // Same as above, but for processing state.
                 this.logger.LogSubmissionAlreadyProcessing(submission.Id);
+                await this.UpdateEnqueuedTime(freshSubmissionForProcessing, enqueuedAt);
                 break;
             case SubmissionProcessingState.Enqueued:
-            case SubmissionProcessingState.Invalid:
             case SubmissionProcessingState.Pending:
+            case SubmissionProcessingState.Invalid:
             default:
                 // Submission is not yet picked up for processing, so we mark it as enqueued.
                 await this.submissionForProcessingData.MarkEnqueued(freshSubmissionForProcessing, enqueuedAt);
@@ -128,5 +131,12 @@ public class SubmissionsCommonBusinessService : ISubmissionsCommonBusinessServic
         var submissionsIds = submissions.Select(s => s.Id).ToList();
 
         await this.submissionForProcessingData.MarkMultipleEnqueued(submissionsIds, enqueuedAt);
+    }
+
+    private async Task UpdateEnqueuedTime(SubmissionForProcessing freshSubmissionForProcessing, DateTimeOffset enqueuedAt)
+    {
+        freshSubmissionForProcessing.EnqueuedAt = enqueuedAt;
+        this.submissionForProcessingData.Update(freshSubmissionForProcessing);
+        await this.submissionForProcessingData.SaveChanges();
     }
 }

--- a/Services/Infrastructure/OJS.Services.Infrastructure/Constants/LoggerMessageDefinitions.cs
+++ b/Services/Infrastructure/OJS.Services.Infrastructure/Constants/LoggerMessageDefinitions.cs
@@ -88,6 +88,9 @@ public static partial class LoggerMessageDefinitions
     [LoggerMessage(1060, LogLevel.Warning, "Submission for processing for Submission #{SubmissionId} is already marked as Processed. Skipping step.")]
     public static partial void LogSubmissionAlreadyProcessed(this ILogger logger, int submissionId);
 
+    [LoggerMessage(1061, LogLevel.Warning, "Submission for processing for Submission #{SubmissionId} is already marked as Processing. Skipping step.")]
+    public static partial void LogSubmissionAlreadyProcessing(this ILogger logger, int submissionId);
+
     [LoggerMessage(1100, LogLevel.Information, "Result for submission #{SubmissionId} processed successfully with SubmissionForProcessing: {@SubmissionForProcessing}")]
     public static partial void LogSubmissionProcessedSuccessfully(this ILogger logger, int submissionId, object submissionForProcessing);
 


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/your_issue_number

**Summary of the changes made**:
1. If submission is already processing we do not mark it as Enqueued.
