### PR TITLE
Fixed compilationDir path creation logic

### DIFF
--- a/Services/Common/OJS.Workers/OJS.Workers.Compilers/DotNetCompiler.cs
+++ b/Services/Common/OJS.Workers/OJS.Workers.Compilers/DotNetCompiler.cs
@@ -30,7 +30,10 @@ namespace OJS.Workers.Compilers
 
         public override string BuildCompilerArguments(string inputFile, string outputFile, string additionalArguments)
         {
-            var compilingDir = $"{Path.GetDirectoryName(inputFile)}\\{CompilationDirectoryName}";
+            var inputFileDirectory = Path.GetDirectoryName(inputFile)
+                ?? throw new DirectoryNotFoundException($"Input file directory not found. Input file path value: {inputFile}");
+
+            var compilingDir = FileHelpers.BuildPath(inputFileDirectory, CompilationDirectoryName);
             Directory.CreateDirectory(compilingDir);
 
             var arguments = new StringBuilder();


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1398

**Summary of the changes made**:
1. Used Path.Combine instead of joining strings
